### PR TITLE
Feature#3 멘토 멘티 대시보드 컴포넌트 구현

### DIFF
--- a/src/features/dashboard/components/DashboardApply/DashboardApplyCard.stories.tsx
+++ b/src/features/dashboard/components/DashboardApply/DashboardApplyCard.stories.tsx
@@ -1,0 +1,20 @@
+import { DashboardApplyCard } from "./DashboardApplyCard";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const PlaceholderLogo: React.ReactNode = <div className="h-5 w-5 rounded-sm bg-zinc-200/80" />;
+
+const meta: Meta<typeof DashboardApplyCard> = {
+    component: DashboardApplyCard,
+};
+
+export default meta;
+type Story = StoryObj<typeof DashboardApplyCard>;
+
+export const Default: Story = {
+    args: {
+        icon: PlaceholderLogo,
+        company: "LG CNS",
+        position: "클라우드 엔지니어",
+        dday: "D-14",
+    },
+};

--- a/src/features/dashboard/components/DashboardApply/DashboardApplyCard.tsx
+++ b/src/features/dashboard/components/DashboardApply/DashboardApplyCard.tsx
@@ -1,0 +1,54 @@
+import { ArrowRight } from "lucide-react";
+
+import { cn } from "@/shared/lib/utils";
+import { Card } from "@/shared/ui/card";
+
+export interface DashboardApplyCardProps extends React.ComponentProps<"div"> {
+    icon: React.ReactNode;
+    company: string;
+    position: string;
+    dday: string;
+    ddayBg?: string;
+}
+
+export const DashboardApplyCard = ({
+    icon,
+    company,
+    position,
+    dday,
+    ddayBg,
+    className,
+    ...props
+}: DashboardApplyCardProps) => {
+    //TODO : dday에 값에 따라 ddayBg 변경
+    const ddayBackGround = "bg-[#EA580C]/10 text-[#EA580C] ring-1 ring-[#EA580C]/20";
+
+    return (
+        <Card {...props} className={cn("rounded-xl border bg-white p-4", className)}>
+            <div className="flex items-start gap-3">
+                <div className="grid h-9 w-9 place-items-center overflow-hidden rounded-md bg-white ring-1 ring-black/5">
+                    {icon}
+                </div>
+
+                <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm leading-6 font-medium text-slate-900">
+                        {company}
+                    </div>
+                    <div className="truncate text-xs leading-5 text-slate-600">{position}</div>
+                </div>
+            </div>
+
+            <div className="mt-3 flex items-center justify-between">
+                <span
+                    className={cn(
+                        "inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ring-1",
+                        ddayBg ?? ddayBackGround,
+                    )}
+                >
+                    {dday}
+                </span>
+                <ArrowRight className="h-4 w-4 text-muted-foreground/70" strokeWidth={2} />
+            </div>
+        </Card>
+    );
+};

--- a/src/features/dashboard/components/DashboardApply/DashboardApplyContainer.tsx
+++ b/src/features/dashboard/components/DashboardApply/DashboardApplyContainer.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/shared/lib/utils";
+
+export interface DashboardApplyContainerProps extends React.ComponentProps<"section"> {
+    className?: string;
+}
+
+export const DashboardApplyContainer = ({
+    className,
+    children,
+    ...props
+}: DashboardApplyContainerProps) => {
+    return (
+        <section
+            {...props}
+            className={cn("rounded-xl border bg-card p-4 sm:p-5 shadow-sm", className)}
+        >
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">{children}</div>
+        </section>
+    );
+};

--- a/src/features/dashboard/components/DashboardApply/DashboardApplyWrapper.tsx
+++ b/src/features/dashboard/components/DashboardApply/DashboardApplyWrapper.tsx
@@ -1,0 +1,38 @@
+import type { PropsWithChildren } from "react";
+
+import { cn } from "@/shared/lib/utils";
+
+export interface DashboardApplyWrapperProps extends PropsWithChildren {
+    title: string;
+    value: number;
+    wrapperClassName?: string;
+    className?: string;
+}
+
+export const DashboardApplyWrapper = ({
+    title,
+    value,
+    wrapperClassName = "bg-zinc-50",
+    className,
+    children,
+}: DashboardApplyWrapperProps) => {
+    return (
+        <div className={cn("flex flex-col", className)}>
+            <div className="mb-2 flex items-center justify-between px-1">
+                <h4 className="text-sm leading-6 font-semibold text-slate-900">{title}</h4>
+                <span className="ml-2 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-zinc-100 px-2 text-xs font-medium text-zinc-700">
+                    {value}
+                </span>
+            </div>
+
+            <div
+                className={cn(
+                    "rounded-xl px-5 py-6 min-h-[420px] sm:min-h-[480px] lg:min-h-[560px]",
+                    wrapperClassName,
+                )}
+            >
+                <div className="flex flex-col gap-4">{children}</div>
+            </div>
+        </div>
+    );
+};

--- a/src/features/dashboard/components/DashboardApply/index.tsx
+++ b/src/features/dashboard/components/DashboardApply/index.tsx
@@ -1,0 +1,3 @@
+export * from "./DashboardApplyCard";
+export * from "./DashboardApplyWrapper";
+export * from "./DashboardApplyContainer";

--- a/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.stories.tsx
+++ b/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.stories.tsx
@@ -1,7 +1,6 @@
 import { Folder } from "lucide-react";
 
-import { DashboardHeaderCard } from "@/features/dashboard/components/DashboardHeader/DashboardHeaderCard";
-
+import { DashboardHeaderCard } from "./DashboardHeaderCard";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const meta: Meta<typeof DashboardHeaderCard> = {

--- a/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.stories.tsx
+++ b/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.stories.tsx
@@ -1,3 +1,5 @@
+import { Folder } from "lucide-react";
+
 import { DashboardHeaderCard } from "@/features/dashboard/components/DashboardHeader/DashboardHeaderCard";
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
@@ -10,5 +12,11 @@ export default meta;
 type Story = StoryObj<typeof DashboardHeaderCard>;
 
 export const Default: Story = {
-    args: {},
+    args: {
+        title: "전체 지원 패키지",
+        value: 12,
+        description: "+2 이번 주",
+        icon: <Folder className="h-5 w-5 text-blue-600" strokeWidth={2} />,
+        iconBg: "bg-blue-50",
+    },
 };

--- a/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.stories.tsx
+++ b/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.stories.tsx
@@ -1,0 +1,14 @@
+import { DashboardHeaderCard } from "@/features/dashboard/components/DashboardHeader/DashboardHeaderCard";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof DashboardHeaderCard> = {
+    component: DashboardHeaderCard,
+};
+
+export default meta;
+type Story = StoryObj<typeof DashboardHeaderCard>;
+
+export const Default: Story = {
+    args: {},
+};

--- a/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.tsx
+++ b/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.tsx
@@ -1,0 +1,51 @@
+import { cn } from "@/shared/lib/utils";
+import { Card, CardTitle, CardDescription } from "@/shared/ui/card";
+
+export interface DashboardHeaderCardProps extends React.ComponentProps<"div"> {
+    title: string;
+    value: number;
+    description: string;
+    icon: React.ReactNode;
+    iconBg?: string;
+}
+
+export const DashboardHeaderCard = ({
+    title,
+    value,
+    description,
+    icon,
+    iconBg,
+    className,
+    ...props
+}: DashboardHeaderCardProps) => {
+    return (
+        <Card
+            {...props}
+            className={cn(
+                "flex-1 min-w-[240px] rounded-lg border bg-card text-card-foreground shadow-sm py-6",
+                className,
+            )}
+        >
+            <div className="flex items-start justify-between gap-4 px-6">
+                <div className="min-w-0">
+                    <CardTitle className="text-[12.84px] leading-[18.3px] text-[#485563] font-normal">
+                        {title}
+                    </CardTitle>
+                    <div className="text-[22.02px] font-semibold leading-tight">{value}</div>
+                    <CardDescription className="mt-1 text-sm text-emerald-600">
+                        {description}
+                    </CardDescription>
+                </div>
+
+                <div
+                    className={cn(
+                        "ml-2 grid h-12 w-12 place-items-center rounded-md bg-blue-50 mt-3",
+                        iconBg,
+                    )}
+                >
+                    {icon}
+                </div>
+            </div>
+        </Card>
+    );
+};

--- a/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.tsx
+++ b/src/features/dashboard/components/DashboardHeader/DashboardHeaderCard.tsx
@@ -28,10 +28,10 @@ export const DashboardHeaderCard = ({
         >
             <div className="flex items-start justify-between gap-4 px-6">
                 <div className="min-w-0">
-                    <CardTitle className="text-[12.84px] leading-[18.3px] text-[#485563] font-normal">
+                    <CardTitle className="text-xs leading-[18px] text-[#485563] font-normal">
                         {title}
                     </CardTitle>
-                    <div className="text-[22.02px] font-semibold leading-tight">{value}</div>
+                    <div className="text-2xl font-semibold leading-tight">{value}</div>
                     <CardDescription className="mt-1 text-sm text-emerald-600">
                         {description}
                     </CardDescription>

--- a/src/features/dashboard/components/DashboardHeader/DashboardHeaderContainer.tsx
+++ b/src/features/dashboard/components/DashboardHeader/DashboardHeaderContainer.tsx
@@ -1,0 +1,18 @@
+import type { PropsWithChildren } from "react";
+
+import { cn } from "@/shared/lib/utils";
+
+export interface DashboardHeaderContainerProps extends PropsWithChildren {
+    className?: string;
+}
+
+export const DashboardHeaderContainer = ({
+    children,
+    className,
+}: DashboardHeaderContainerProps) => {
+    return (
+        <section className={cn("flex flex-wrap items-stretch gap-4", className)}>
+            {children}
+        </section>
+    );
+};

--- a/src/features/dashboard/components/DashboardHeader/index.tsx
+++ b/src/features/dashboard/components/DashboardHeader/index.tsx
@@ -1,0 +1,2 @@
+export * from "./DashboardHeaderCard";
+export * from "./DashboardHeaderContainer";

--- a/src/pages/mentee/MenteeDashboardPage.tsx
+++ b/src/pages/mentee/MenteeDashboardPage.tsx
@@ -9,7 +9,7 @@ export default function MenteeDashboardPage() {
     return (
         <div className="px-6 py-6">
             <h1 className="text-xl font-semibold text-foreground">취업 트래커 대시보드</h1>
-            <h2 className="mt-1 text-[14.68px] leading-[22px] text-[#485563] font-normal">
+            <h2 className="mt-1 text-sm leading-[22px] text-[#485563] font-normal">
                 모든 취업 활동을 한눈에 관리하세요
             </h2>
 

--- a/src/pages/mentee/MenteeDashboardPage.tsx
+++ b/src/pages/mentee/MenteeDashboardPage.tsx
@@ -1,9 +1,17 @@
 import { Folder, UserRoundPen, Clock3, UserRound } from "lucide-react";
 
 import {
+    DashboardApplyCard,
+    DashboardApplyWrapper,
+    DashboardApplyContainer,
+} from "@/features/dashboard/components/DashboardApply";
+import {
     DashboardHeaderContainer,
     DashboardHeaderCard,
 } from "@/features/dashboard/components/DashboardHeader";
+
+//TODO : 기업 이미지 불러오기
+const PlaceholderLogo: React.ReactNode = <div className="h-5 w-5 rounded-sm bg-zinc-200/80" />;
 
 export default function MenteeDashboardPage() {
     return (
@@ -43,6 +51,50 @@ export default function MenteeDashboardPage() {
                     iconBg="bg-violet-50"
                 />
             </DashboardHeaderContainer>
+
+            <h3 className="mt-8 mb-3 text-lg leading-7 font-semibold text-slate-900">지원 현황</h3>
+
+            <DashboardApplyContainer>
+                <DashboardApplyWrapper title="지원 예정" value={1} wrapperClassName="bg-zinc-50">
+                    <DashboardApplyCard
+                        icon={PlaceholderLogo}
+                        company="LG CNS"
+                        position="클라우드 엔지니어"
+                        dday="D-14"
+                    />
+                </DashboardApplyWrapper>
+
+                <DashboardApplyWrapper
+                    title="서류 작성 중"
+                    value={1}
+                    wrapperClassName="bg-yellow-50"
+                >
+                    <DashboardApplyCard
+                        icon={PlaceholderLogo}
+                        company="삼성전자"
+                        position="DX부문 소프트웨어 개발"
+                        dday="D-7"
+                    />
+                </DashboardApplyWrapper>
+
+                <DashboardApplyWrapper title="제출 완료" value={1} wrapperClassName="bg-sky-50">
+                    <DashboardApplyCard
+                        icon={PlaceholderLogo}
+                        company="네이버"
+                        position="백엔드 개발자"
+                        dday="D-3"
+                    />
+                </DashboardApplyWrapper>
+
+                <DashboardApplyWrapper title="면접 진행" value={1} wrapperClassName="bg-green-50">
+                    <DashboardApplyCard
+                        icon={PlaceholderLogo}
+                        company="카카오"
+                        position="프론트엔드 개발자"
+                        dday="D-21"
+                    />
+                </DashboardApplyWrapper>
+            </DashboardApplyContainer>
         </div>
     );
 }

--- a/src/pages/mentee/MenteeDashboardPage.tsx
+++ b/src/pages/mentee/MenteeDashboardPage.tsx
@@ -1,3 +1,48 @@
+import { Folder, UserRoundPen, Clock3, UserRound } from "lucide-react";
+
+import {
+    DashboardHeaderContainer,
+    DashboardHeaderCard,
+} from "@/features/dashboard/components/DashboardHeader";
+
 export default function MenteeDashboardPage() {
-    return <div>Mentee Dashboard Page</div>;
+    return (
+        <div className="px-6 py-6">
+            <h1 className="text-xl font-semibold text-foreground">취업 트래커 대시보드</h1>
+            <h2 className="mt-1 text-[14.68px] leading-[22px] text-[#485563] font-normal">
+                모든 취업 활동을 한눈에 관리하세요
+            </h2>
+
+            <DashboardHeaderContainer className="mt-4">
+                <DashboardHeaderCard
+                    title="전체 지원 패키지"
+                    value={12}
+                    description="+2 이번 주"
+                    icon={<Folder className="h-5 w-5 text-blue-600" strokeWidth={2} />}
+                    iconBg="bg-blue-50"
+                />
+                <DashboardHeaderCard
+                    title="진행 중인 멘토링"
+                    value={3}
+                    description="+1 이번 주"
+                    icon={<UserRoundPen className="h-5 w-5 text-emerald-600" strokeWidth={2} />}
+                    iconBg="bg-emerald-50"
+                />
+                <DashboardHeaderCard
+                    title="이번 주 마감"
+                    value={2}
+                    description=" - "
+                    icon={<Clock3 className="h-5 w-5 text-orange-600" strokeWidth={2} />}
+                    iconBg="bg-orange-50"
+                />
+                <DashboardHeaderCard
+                    title="면접 대기"
+                    value={1}
+                    description="+1 이번 주"
+                    icon={<UserRound className="h-5 w-5 text-violet-600" strokeWidth={2} />}
+                    iconBg="bg-violet-50"
+                />
+            </DashboardHeaderContainer>
+        </div>
+    );
 }


### PR DESCRIPTION
## ✅ Linked Issue

- #3

## 🔍 What I did

- DashboardHeaderCard 컴포넌트를 추가했습니다.
- DashboardHeaderContainter 컴포넌트를 추가했습니다.
- 위 두 컴포넌트를 MenteeDashboardPage에 통합했습니다.



## 💡 Why I did it

- 컴포넌트와 카드를 분리해서 레이아웃과 컨텐츠를 독립적으로 관리하기 편하게 했습니다.

## 🧠 What I learned

- ComponentProps<"div">  VS  HTMLAttributes<HTMLDivElement>
  - 둘다 children을 포함하지만 ComponentsProps의 경우는 reft도 포함한다. 그래서 ref가 필요없을 때 명시적으로 배제하고 싶으면 전자를 써도 무방하다.


## 🔧 Additional context

- 처음에 DashboardHeaderCard의 props 중에서 width를 CSSProperties["width"]로 타입을 지정해서 number(px), string(~%) 둘다 커버하려 했는데 상위 레이아웃으로 해결하는 게 더 직관적일 것 같아서 width prop 자체를 없애고 필요할 경우 인라인으로 직접 제어하기로하고 현재는 클래스 기반으로만 폭이 결정되도록 했습니다.

## 🚧 TODO (if any)

- 지원 현황 대시보드 컴포넌트 마저 구현하기



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Mentee Dashboard with a header of summary cards showing key stats at a glance.
  * Added four dashboard summary cards with icons and color cues: total packages (12, +2 this week), active mentorships (3, +1), deadlines this week (2), interviews pending (1, +1).
  * Added a “지원 현황” section with grouped application panels and individual application cards (company, position, D-day).
* **Documentation**
  * Added Storybook stories for the header and application card components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->