### PR TITLE
Feature/[#7] 지원 기업 상세 보기 구현 

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,157 +7,160 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = "2.10.5";
-const INTEGRITY_CHECKSUM = "f5825c521429caf22a4dd13b66e243af";
-const IS_MOCKED_RESPONSE = Symbol("isMockedResponse");
-const activeClientIds = new Set();
+const PACKAGE_VERSION = '2.10.5'
+const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
 
-addEventListener("install", function () {
-    self.skipWaiting();
-});
+addEventListener('install', function () {
+  self.skipWaiting()
+})
 
-addEventListener("activate", function (event) {
-    event.waitUntil(self.clients.claim());
-});
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
 
-addEventListener("message", async function (event) {
-    const clientId = Reflect.get(event.source || {}, "id");
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
 
-    if (!clientId || !self.clients) {
-        return;
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
     }
 
-    const client = await self.clients.get(clientId);
-
-    if (!client) {
-        return;
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
     }
 
-    const allClients = await self.clients.matchAll({
-        type: "window",
-    });
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
 
-    switch (event.data) {
-        case "KEEPALIVE_REQUEST": {
-            sendToClient(client, {
-                type: "KEEPALIVE_RESPONSE",
-            });
-            break;
-        }
-
-        case "INTEGRITY_CHECK_REQUEST": {
-            sendToClient(client, {
-                type: "INTEGRITY_CHECK_RESPONSE",
-                payload: {
-                    packageVersion: PACKAGE_VERSION,
-                    checksum: INTEGRITY_CHECKSUM,
-                },
-            });
-            break;
-        }
-
-        case "MOCK_ACTIVATE": {
-            activeClientIds.add(clientId);
-
-            sendToClient(client, {
-                type: "MOCKING_ENABLED",
-                payload: {
-                    client: {
-                        id: client.id,
-                        frameType: client.frameType,
-                    },
-                },
-            });
-            break;
-        }
-
-        case "MOCK_DEACTIVATE": {
-            activeClientIds.delete(clientId);
-            break;
-        }
-
-        case "CLIENT_CLOSED": {
-            activeClientIds.delete(clientId);
-
-            const remainingClients = allClients.filter((client) => {
-                return client.id !== clientId;
-            });
-
-            // Unregister itself when there are no more clients
-            if (remainingClients.length === 0) {
-                self.registration.unregister();
-            }
-
-            break;
-        }
-    }
-});
-
-addEventListener("fetch", function (event) {
-    // Bypass navigation requests.
-    if (event.request.mode === "navigate") {
-        return;
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
     }
 
-    // Opening the DevTools triggers the "only-if-cached" request
-    // that cannot be handled by the worker. Bypass such requests.
-    if (event.request.cache === "only-if-cached" && event.request.mode !== "same-origin") {
-        return;
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
     }
 
-    // Bypass all requests when there are no active clients.
-    // Prevents the self-unregistered worked from handling requests
-    // after it's been deleted (still remains active until the next reload).
-    if (activeClientIds.size === 0) {
-        return;
-    }
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
 
-    const requestId = crypto.randomUUID();
-    event.respondWith(handleRequest(event, requestId));
-});
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
 
 /**
  * @param {FetchEvent} event
  * @param {string} requestId
  */
 async function handleRequest(event, requestId) {
-    const client = await resolveMainClient(event);
-    const requestCloneForEvents = event.request.clone();
-    const response = await getResponse(event, client, requestId);
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(event, client, requestId)
 
-    // Send back the response clone for the "response:*" life-cycle events.
-    // Ensure MSW is active and ready to handle the message, otherwise
-    // this message will pend indefinitely.
-    if (client && activeClientIds.has(client.id)) {
-        const serializedRequest = await serializeRequest(requestCloneForEvents);
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
 
-        // Clone the response so both the client and the library could consume it.
-        const responseClone = response.clone();
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
 
-        sendToClient(
-            client,
-            {
-                type: "RESPONSE",
-                payload: {
-                    isMockedResponse: IS_MOCKED_RESPONSE in response,
-                    request: {
-                        id: requestId,
-                        ...serializedRequest,
-                    },
-                    response: {
-                        type: responseClone.type,
-                        status: responseClone.status,
-                        statusText: responseClone.statusText,
-                        headers: Object.fromEntries(responseClone.headers.entries()),
-                        body: responseClone.body,
-                    },
-                },
-            },
-            responseClone.body ? [serializedRequest.body, responseClone.body] : [],
-        );
-    }
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
 
-    return response;
+  return response
 }
 
 /**
@@ -169,30 +172,30 @@ async function handleRequest(event, requestId) {
  * @returns {Promise<Client | undefined>}
  */
 async function resolveMainClient(event) {
-    const client = await self.clients.get(event.clientId);
+  const client = await self.clients.get(event.clientId)
 
-    if (activeClientIds.has(event.clientId)) {
-        return client;
-    }
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
 
-    if (client?.frameType === "top-level") {
-        return client;
-    }
+  if (client?.frameType === 'top-level') {
+    return client
+  }
 
-    const allClients = await self.clients.matchAll({
-        type: "window",
-    });
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
 
-    return allClients
-        .filter((client) => {
-            // Get only those clients that are currently visible.
-            return client.visibilityState === "visible";
-        })
-        .find((client) => {
-            // Find the client ID that's recorded in the
-            // set of clients that have registered the worker.
-            return activeClientIds.has(client.id);
-        });
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
 }
 
 /**
@@ -202,71 +205,73 @@ async function resolveMainClient(event) {
  * @returns {Promise<Response>}
  */
 async function getResponse(event, client, requestId) {
-    // Clone the request because it might've been already used
-    // (i.e. its body has been read and sent to the client).
-    const requestClone = event.request.clone();
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
 
-    function passthrough() {
-        // Cast the request headers to a new Headers instance
-        // so the headers can be manipulated with.
-        const headers = new Headers(requestClone.headers);
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
 
-        // Remove the "accept" header value that marked this request as passthrough.
-        // This prevents request alteration and also keeps it compliant with the
-        // user-defined CORS policies.
-        const acceptHeader = headers.get("accept");
-        if (acceptHeader) {
-            const values = acceptHeader.split(",").map((value) => value.trim());
-            const filteredValues = values.filter((value) => value !== "msw/passthrough");
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
 
-            if (filteredValues.length > 0) {
-                headers.set("accept", filteredValues.join(", "));
-            } else {
-                headers.delete("accept");
-            }
-        }
-
-        return fetch(requestClone, { headers });
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
     }
 
-    // Bypass mocking when the client is not active.
-    if (!client) {
-        return passthrough();
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
     }
 
-    // Bypass initial page load requests (i.e. static assets).
-    // The absence of the immediate/parent client in the map of the active clients
-    // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
-    // and is not ready to handle requests.
-    if (!activeClientIds.has(client.id)) {
-        return passthrough();
+    case 'PASSTHROUGH': {
+      return passthrough()
     }
+  }
 
-    // Notify the client that a request has been intercepted.
-    const serializedRequest = await serializeRequest(event.request);
-    const clientMessage = await sendToClient(
-        client,
-        {
-            type: "REQUEST",
-            payload: {
-                id: requestId,
-                ...serializedRequest,
-            },
-        },
-        [serializedRequest.body],
-    );
-
-    switch (clientMessage.type) {
-        case "MOCK_RESPONSE": {
-            return respondWithMock(clientMessage.data);
-        }
-
-        case "PASSTHROUGH": {
-            return passthrough();
-        }
-    }
-
-    return passthrough();
+  return passthrough()
 }
 
 /**
@@ -276,19 +281,22 @@ async function getResponse(event, client, requestId) {
  * @returns {Promise<any>}
  */
 function sendToClient(client, message, transferrables = []) {
-    return new Promise((resolve, reject) => {
-        const channel = new MessageChannel();
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
 
-        channel.port1.onmessage = (event) => {
-            if (event.data && event.data.error) {
-                return reject(event.data.error);
-            }
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
 
-            resolve(event.data);
-        };
+      resolve(event.data)
+    }
 
-        client.postMessage(message, [channel.port2, ...transferrables.filter(Boolean)]);
-    });
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
 }
 
 /**
@@ -296,41 +304,41 @@ function sendToClient(client, message, transferrables = []) {
  * @returns {Response}
  */
 function respondWithMock(response) {
-    // Setting response status code to 0 is a no-op.
-    // However, when responding with a "Response.error()", the produced Response
-    // instance will have status code set to 0. Since it's not possible to create
-    // a Response instance with status code 0, handle that use-case separately.
-    if (response.status === 0) {
-        return Response.error();
-    }
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
 
-    const mockedResponse = new Response(response.body, response);
+  const mockedResponse = new Response(response.body, response)
 
-    Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
-        value: true,
-        enumerable: true,
-    });
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
 
-    return mockedResponse;
+  return mockedResponse
 }
 
 /**
  * @param {Request} request
  */
 async function serializeRequest(request) {
-    return {
-        url: request.url,
-        mode: request.mode,
-        method: request.method,
-        headers: Object.fromEntries(request.headers.entries()),
-        cache: request.cache,
-        credentials: request.credentials,
-        destination: request.destination,
-        integrity: request.integrity,
-        redirect: request.redirect,
-        referrer: request.referrer,
-        referrerPolicy: request.referrerPolicy,
-        body: await request.arrayBuffer(),
-        keepalive: request.keepalive,
-    };
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
 }

--- a/src/entities/applications/components/ApplicationsSummary/ApplicationsSummaryCard.stories.tsx
+++ b/src/entities/applications/components/ApplicationsSummary/ApplicationsSummaryCard.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ApplicationsSummaryCard } from "./ApplicationsSummaryCard";
+
+const meta: Meta<typeof ApplicationsSummaryCard> = {
+  title: "entities/application/ApplicationsSummaryCard",
+  component: ApplicationsSummaryCard,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "지원 기업 상단 요약 카드. 회사명 24/Bold, 포지션 18/Regular, 메타 라벨 14/Regular, 메타 값 14/Medium, 진행률 텍스트 14, 우측 버튼(리뷰룸/채용공고 보기) 16/Medium 스펙을 반영합니다.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-6 max-w-5xl">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    companyLogo: { control: "text" },
+    companyName: { control: "text" },
+    applyPosition: { control: "text" },
+    appliedDate: { control: "text" },
+    location: { control: "text" },
+    jobType: { control: "text" },
+    field: { control: "text" },
+    progress: { control: { type: "range", min: 0, max: 100, step: 5 } },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ApplicationsSummaryCard>;
+
+const baseArgs = {
+  companyLogo: "/assets/samsung.png",
+  companyName: "삼성전자",
+  applyPosition: "DX 부문 소프트웨어 개발",
+  appliedDate: "2024-01-15",
+  location: "서울",
+  jobType: "정규직",
+  field: "신입",
+};
+
+export const Default: Story = {
+  args: {
+    ...baseArgs,
+    progress: 0,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "일반적인 진행률 0% 케이스. 상단 타이포/버튼 크기/메타 그리드 간격이 의도대로 보이는지 확인하세요.",
+      },
+    },
+  },
+};
+
+export const Progress20: Story = {
+  args: {
+    ...baseArgs,
+    progress: 20,
+  },
+  name: "진행률 20%",
+};
+
+export const Progress50: Story = {
+  args: {
+    ...baseArgs,
+    progress: 50,
+  },
+  name: "진행률 50%",
+};
+
+export const Progress100: Story = {
+  args: {
+    ...baseArgs,
+    progress: 100,
+  },
+  name: "진행률 100%",
+  parameters: {
+    docs: {
+      description: {
+        story: "완료 상태(100%). 진행률 바/텍스트 색이 과도하게 튀지 않는지 체크합니다.",
+      },
+    },
+  },
+};

--- a/src/entities/applications/components/ApplicationsSummary/ApplicationsSummaryCard.tsx
+++ b/src/entities/applications/components/ApplicationsSummary/ApplicationsSummaryCard.tsx
@@ -1,0 +1,129 @@
+import type { HTMLAttributes } from "react";
+
+import { cn } from "@/shared/lib/utils";
+import { Button } from "@/shared/ui/button";
+
+export interface ApplicationsSummaryCardProps extends HTMLAttributes<HTMLElement> {
+    companyLogo: string;
+    companyName: string;
+    applyPosition: string;
+    appliedDate: string;
+    location: string;
+    jobType: string;
+    field: string;
+    progress: number;
+}
+
+interface CardHeaderProps {
+    companyLogo: string;
+    companyName: string;
+    applyPosition: string;
+    appliedDate: string;
+    location: string;
+    jobType: string;
+    field: string;
+    actions?: React.ReactNode;
+}
+const CardHeader = ({
+  companyLogo,
+  companyName,
+  applyPosition,
+  appliedDate,
+  location,
+  jobType,
+  field,
+  actions,
+}: CardHeaderProps) => (
+  <div className="flex items-start gap-4">
+    <img src={companyLogo} alt={`${companyName} 로고`} className="h-12 w-12 rounded-md object-contain" />
+
+    <div className="flex-1 min-w-0">
+      <h2 className="truncate text-2xl font-bold text-gray-900">{companyName}</h2>
+      <p className="truncate text-lg font-normal text-gray-600">{applyPosition}</p>
+
+      <div className="mt-3 grid grid-cols-2 md:grid-cols-4 gap-x-8 gap-y-4">
+        <MetaBlock label="지원일" value={appliedDate} />
+        <MetaBlock label="근무지" value={location} />
+        <MetaBlock label="고용형태" value={jobType} />
+        <MetaBlock label="경력" value={field} />
+      </div>
+    </div>
+
+    {actions && <div className="ml-auto flex gap-2">{actions}</div>}
+  </div>
+);
+
+interface CardProgressProps {
+    progress: number;
+}
+const CardProgress = ({ progress }: CardProgressProps) => {
+  const safe = Number.isFinite(progress) ? progress : 0;
+  const clamped = Math.min(100, Math.max(0, safe));
+
+  return (
+    <div className="mt-6">
+      <div className="mb-1 flex items-center justify-between text-sm text-gray-500">
+        <span className="font-normal">전체 진행률</span>
+        <span className="font-normal">{clamped}%</span>
+      </div>
+      <progress
+        value={clamped}
+        max={100}
+        aria-label="전체 진행률"
+        className={cn(
+          "h-2 w-full rounded-full",
+          "[&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-gray-200",
+          "[&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:transition-all [&::-webkit-progress-value]:duration-300",
+          clamped >= 70
+            ? "[&::-webkit-progress-value]:bg-green-500 [&::-moz-progress-bar]:bg-green-500"
+            : clamped >= 40
+            ? "[&::-webkit-progress-value]:bg-blue-500 [&::-moz-progress-bar]:bg-blue-500"
+            : "[&::-webkit-progress-value]:bg-red-500 [&::-moz-progress-bar]:bg-red-500"
+        )}
+      />
+    </div>
+  );
+};
+
+const MetaBlock = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex flex-col gap-1">
+    <span className="text-sm font-normal text-gray-500">{label}</span>
+    <span className="text-sm font-medium text-gray-900">{value}</span>
+  </div>
+);
+
+export const ApplicationsSummaryCard = ({
+  companyLogo,
+  companyName,
+  applyPosition,
+  appliedDate,
+  location,
+  jobType,
+  field,
+  progress,
+  ...rest
+}: ApplicationsSummaryCardProps) => {
+  return (
+    <section
+      {...rest}
+      className={cn("w-full rounded-xl border border-gray-200 bg-white p-6 shadow-sm", rest.className)}
+    >
+      <CardHeader
+        companyLogo={companyLogo}
+        companyName={companyName}
+        applyPosition={applyPosition}
+        appliedDate={appliedDate}
+        location={location}
+        jobType={jobType}
+        field={field}
+        actions={
+          <>
+          <Button className="text-base font-medium bg-blue-600 hover:bg-blue-700 text-white">리뷰룸</Button> 
+          <Button variant="outline" className="text-base font-medium">채용공고 보기</Button>
+          </>
+        }
+      />
+      <CardProgress progress={progress} />
+    </section>
+  );
+};

--- a/src/entities/document/components/DocumentList.stories.tsx
+++ b/src/entities/document/components/DocumentList.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DocumentList } from "./DocumentList";
+
+const meta: Meta<typeof DocumentList> = {
+  title: "Entities/Document/DocumentList",
+  component: DocumentList,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "문서(이력서/자기소개서/포트폴리오) 버전 리스트 컴포넌트. 폴더 아이콘 섹션 헤더 + 파일 아이콘 버전 아이템 + 우측 액션(보기/삭제) 구성을 제공합니다.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-6 max-w-3xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof DocumentList>;
+
+export const WithResumes: Story = {
+  args: {
+    title: "이력서",
+    versions: [
+      { id: "1", title: "v1.2", description: "최종본", date: "2024.01.20" },
+      { id: "2", title: "v1.1", description: "1차 피드백 반영", date: "2024.01.18" },
+      { id: "3", title: "v1.0", description: "초안", date: "2024.01.15" },
+    ],
+    onCreateVersion: () => console.log("새 버전 만들기 클릭"),
+    onViewVersion: (id) => console.log("보기 클릭:", id),
+    onDeleteVersion: (id) => console.log("삭제 클릭:", id),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    title: "이력서",
+    versions: [],
+    onCreateVersion: () => console.log("이력서 새 버전 만들기"),
+  },
+};
+
+export const ManyItems: Story = {
+  args: {
+    title: "이력서",
+    versions: Array.from({ length: 10 }).map((_, i) => ({
+      id: String(i + 1),
+      title: `v1.${i}`,
+      description: i % 2 ? "리뷰 반영" : "작업본",
+      date: `2024.02.${String(i + 1).padStart(2, "0")}`,
+    })),
+    onCreateVersion: () => console.log("이력서 새 버전 만들기"),
+    onViewVersion: (id) => console.log("보기 클릭:", id),
+    onDeleteVersion: (id) => console.log("삭제 클릭:", id),
+  },
+};
+
+export const LongText: Story = {
+  args: {
+    title: "이력서",
+    versions: [
+      {
+        id: "1",
+        title: "v1.2-긴-라벨-예시-긴-라벨-예시",
+        description:
+          "제목/프로젝트/스킬 상세가 길어지는 경우를 가정한 설명 텍스트 예시입니다. 가독성을 유지하는지 확인하세요.",
+        date: "2024.01.20",
+      },
+    ],
+    onCreateVersion: () => console.log("새 버전 만들기 클릭"),
+    onViewVersion: (id) => console.log("보기 클릭:", id),
+    onDeleteVersion: (id) => console.log("삭제 클릭:", id),
+  },
+};

--- a/src/entities/document/components/DocumentList.tsx
+++ b/src/entities/document/components/DocumentList.tsx
@@ -1,0 +1,114 @@
+import { Eye, Trash, Folder, FileText } from "lucide-react";
+import { Button } from "@/shared/ui/button";
+import { Card, CardContent } from "@/shared/ui/card";
+import type { HTMLAttributes } from "react";
+import { cn } from "@/shared/lib/utils";
+
+export interface DocumentVersion {
+  id: string;
+  title: string;
+  description: string;
+  date: string;
+}
+
+export interface DocumentListProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  versions: DocumentVersion[];
+  onCreateVersion?: () => void;
+  onViewVersion?: (id: string) => void;
+  onDeleteVersion?: (id: string) => void;
+}
+
+export const DocumentList = ({
+  title,
+  versions,
+  onCreateVersion,
+  onViewVersion,
+  onDeleteVersion,
+  className,
+  ...rest
+}: DocumentListProps) => (
+  <Card className={cn("border border-gray-200", className)} {...rest}>
+    <CardContent className="p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="grid size-6 place-items-center rounded-md border border-indigo-100 bg-indigo-50 text-indigo-500">
+            <Folder size={14} />
+          </div>
+          <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+        </div>
+
+        <Button
+          type="button"
+          onClick={onCreateVersion}
+          className="text-base font-medium bg-blue-600 hover:bg-blue-700 text-white"
+        >
+          + 새 버전 만들기
+        </Button>
+      </div>
+
+      {versions.length === 0 ? (
+        <div
+          className="grid place-items-center rounded-lg border border-dashed border-gray-200 bg-white py-10 text-center"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="mb-2 text-sm text-gray-600">아직 생성된 버전이 없습니다.</p>
+          <Button
+            type="button"
+            onClick={onCreateVersion}
+            className="text-base font-medium bg-blue-600 hover:bg-blue-700 text-white"
+          >
+            새 버전 만들기
+          </Button>
+        </div>
+      ) : (
+        <ul className="space-y-2" role="list">
+          {versions.map((v) => (
+            <li
+              key={v.id}
+              className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-3 py-2"
+              role="listitem"
+            >
+              <div className="flex items-center gap-3">
+                <div className="grid size-9 place-items-center rounded-lg border border-indigo-100 bg-indigo-50 text-indigo-500">
+                  <FileText size={16} />
+                </div>
+                <div>
+                  <p className="text-base font-semibold text-gray-900">{v.title}</p>
+                  <p className="text-sm font-normal text-gray-600">{v.description}</p>
+                  <p className="text-xs font-normal text-gray-400">{v.date}</p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  aria-label="보기"
+                  title="보기"
+                  onClick={() => onViewVersion?.(v.id)}
+                  disabled={!onViewVersion}
+                >
+                  <Eye size={16} />
+                </Button>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  aria-label="삭제"
+                  title="삭제"
+                  onClick={() => onDeleteVersion?.(v.id)}
+                  disabled={!onDeleteVersion}
+                >
+                  <Trash size={16} />
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </CardContent>
+  </Card>
+);

--- a/src/pages/mentee/applications/ApplicationDetailPage.tsx
+++ b/src/pages/mentee/applications/ApplicationDetailPage.tsx
@@ -1,0 +1,21 @@
+import { ApplicationsSummaryCard } from "@/entities/applications/components/ApplicationsSummary/ApplicationsSummaryCard";
+import { ApplicationsDocumentsWidget } from "@/widgets/applications/ApplicationsDocumentsWidget";
+
+export default function ApplicationDetailPage() {
+  return (
+    <div className="p-6 space-y-6">
+      <ApplicationsSummaryCard
+        companyLogo="/assets/samsung.png"
+        companyName="삼성전자"
+        applyPosition="DX부문 소프트웨어 개발"
+        appliedDate="2024-01-15"
+        location="서울"
+        jobType="정규직"
+        field="신입"
+        progress={60}
+      />
+
+      <ApplicationsDocumentsWidget />
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -12,6 +12,7 @@ import MenteeDashboardPage from "@/pages/mentee/MenteeDashboardPage";
 import MenteeSearchMentorPage from "@/pages/mentee/MenteeSearchMentorPage";
 import MenteeSettingsPage from "@/pages/mentee/MenteeSettingsPage";
 import DocumentDiffPage from "@/pages/mentee/applications/DocumentDiffPage";
+import ApplicationDetailPage from "@/pages/mentee/applications/ApplicationDetailPage";
 
 const routes = createRoutesFromElements(
     <Fragment>
@@ -31,8 +32,12 @@ const routes = createRoutesFromElements(
                 <Route path="search" element={<MenteeSearchMentorPage />} />
                 <Route path="settings" element={<MenteeSettingsPage />} />
 
+                <Route path="applications">
+
+                </Route>
                 <Route path="applications/:applicationId">
                     <Route index></Route>
+                    <Route path= "resume" element={<ApplicationDetailPage />} />
                     <Route path="diff" element={<DocumentDiffPage />} />
                 </Route>
             </Route>

--- a/src/widgets/applications/ApplicationsDocumentsWidget.tsx
+++ b/src/widgets/applications/ApplicationsDocumentsWidget.tsx
@@ -1,0 +1,66 @@
+import { FileText, BookText, FolderClosed } from "lucide-react";
+
+import { DocumentList } from "@/entities/document/components/DocumentList";
+
+import { Tab } from "@/shared/components/Tab/Tab";
+import { TabItem } from "@/shared/components/Tab/TabItem";
+import { TabNavBar } from "@/shared/components/Tab/TabNavBar";
+import { TabNavItem } from "@/shared/components/Tab/TabNavItem";
+
+export const ApplicationsDocumentsWidget = () => {
+    return (
+        <section className="mt-6 overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <Tab defaultActiveTab="이력서">
+                <TabNavBar>
+                    <TabNavItem icon={<FileText size={16} />} label="이력서" indicator={null} />
+                    <TabNavItem icon={<BookText size={16} />} label="자기소개서" indicator={null} />
+                    <TabNavItem
+                        icon={<FolderClosed size={16} />}
+                        label="포트폴리오"
+                        indicator={null}
+                    />
+                </TabNavBar>
+
+                <div className="p-4">
+                    <TabItem menu="이력서">
+                        <DocumentList
+                            title="이력서"
+                            versions={[
+                                {
+                                    id: "1",
+                                    title: "v1.2",
+                                    description: "최종본",
+                                    date: "2024.01.20",
+                                },
+                                {
+                                    id: "2",
+                                    title: "v1.1",
+                                    description: "1차 피드백 반영",
+                                    date: "2024.01.18",
+                                },
+                                { id: "3", title: "v1.0", description: "초안", date: "2024.01.15" },
+                            ]}
+                            onCreateVersion={() => alert("이력서 새 버전")}
+                        />
+                    </TabItem>
+
+                    <TabItem menu="자기소개서">
+                        <DocumentList
+                            title="자기소개서"
+                            versions={[]}
+                            onCreateVersion={() => alert("자기소개서 새 버전")}
+                        />
+                    </TabItem>
+
+                    <TabItem menu="포트폴리오">
+                        <DocumentList
+                            title="포트폴리오"
+                            versions={[]}
+                            onCreateVersion={() => alert("포트폴리오 새 버전")}
+                        />
+                    </TabItem>
+                </div>
+            </Tab>
+        </section>
+    );
+};


### PR DESCRIPTION
## ✅ Linked Issue

- Resolves #7

## 🔍 What I did

- `ApplicationsSummaryCard` 컴포넌트를 추가했습니다. (회사명, 직무, 근무지, 고용형태, 경력, 마감일, 진행률 표시)
- `DocumentList` 컴포넌트를 추가했습니다. (문서 버전 리스트 + 새 버전 만들기/보기/삭제 액션)
- `ApplicationsDocumentsWidget` 위젯을 추가했습니다. (이력서/자기소개서/포트폴리오 탭 구조)
- `ApplicationDetailPage`를 추가했습니다. (상단 요약 카드 + 하단 문서 위젯으로 구성)
- 라우터를 수정하여 `/mentee/applications/:applicationId/resumes` 경로로 상세 페이지 접근 가능하도록 했습니다.
- 각 컴포넌트별 Storybook을 작성했습니다.


## 💡 Why I did it

- 카드/리스트를 독립된 컴포넌트로 분리하여 재사용성과 유지보수성을 높이고, UI 일관성을 유지하려 했습니다.

-

## 🧠 What I learned

- Storybook을 통해 다양한 상태((Empty, 진행률 0/20/50/100, 긴 텍스트 등)를 시뮬레이션하며 UI 컴포넌트의 안정성을 보장하는 흐름을 익혔습니다.

## 🚧 TODO (if any)

- 자기소개서, 포트폴리오 부분 추가 구현하기


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Application Detail page with a summary card and a tabbed documents widget (résumé, cover letter, portfolio) including version lists and quick actions.
  - Introduced Document List UI for viewing, creating, and managing document versions.
  - Added route: /mentee/applications/:applicationId/resume.
- Documentation
  - Added Storybook stories for ApplicationsSummaryCard and DocumentList with multiple scenarios.
- Chores
  - Improved development mock service worker lifecycle for more reliable request mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->