### PR TITLE
Feature#24 [김지훈] 멘티 지원내역 대시보드 DnD 고도화

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.542.0",
     "react": "^19.1.1",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
     "react-pdf": "^10.1.0",

--- a/src/features/dashboard/components/DashboardApply/DashboardApplyWrapper.tsx
+++ b/src/features/dashboard/components/DashboardApply/DashboardApplyWrapper.tsx
@@ -7,6 +7,9 @@ export interface DashboardApplyWrapperProps extends PropsWithChildren {
     value: number;
     wrapperClassName?: string;
     className?: string;
+    droppableRef?: React.Ref<HTMLDivElement>;
+    isOver?: boolean;
+    canDrop?: boolean;
 }
 
 export const DashboardApplyWrapper = ({
@@ -15,6 +18,9 @@ export const DashboardApplyWrapper = ({
     wrapperClassName = "bg-zinc-50",
     className,
     children,
+    droppableRef,
+    isOver,
+    canDrop,
 }: DashboardApplyWrapperProps) => {
     return (
         <div className={cn("flex flex-col", className)}>
@@ -26,9 +32,12 @@ export const DashboardApplyWrapper = ({
             </div>
 
             <div
+                ref={droppableRef}
                 className={cn(
-                    "rounded-xl px-5 py-6 min-h-[420px] sm:min-h-[480px] lg:min-h-[560px]",
+                    "rounded-xl px-5 py-6 min-h-[420px] sm:min-h-[480px] lg:min-h-[560px] transition outline-offset-0",
                     wrapperClassName,
+                    isOver && canDrop && "outline-2 outline-dashed outline-slate-400/70",
+                    isOver && !canDrop && "opacity-70",
                 )}
             >
                 <div className="flex flex-col gap-4">{children}</div>

--- a/src/features/dashboard/dnd/DndApplyCard.tsx
+++ b/src/features/dashboard/dnd/DndApplyCard.tsx
@@ -1,0 +1,38 @@
+import { useDrag } from "react-dnd";
+
+import {
+    DashboardApplyCard,
+    type DashboardApplyCardProps,
+} from "@/features/dashboard/components/DashboardApply";
+import { DND_ITEM_TYPES, type Section } from "@/features/dashboard/dnd/types";
+
+import { cn } from "@/shared/lib/utils";
+
+export interface DndApplyCardProps extends DashboardApplyCardProps {
+    id: string;
+    from: Section;
+    origin: number;
+    className?: string;
+}
+
+export const DndApplyCard = ({ id, from, origin, className, ...props }: DndApplyCardProps) => {
+    const [{ isDragging }, dragRef] = useDrag(
+        () => ({
+            type: DND_ITEM_TYPES.APPLY_CARD,
+            item: { id, from, origin },
+            collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+        }),
+        [id, from, origin],
+    );
+
+    return (
+        <div
+            ref={(node) => {
+                dragRef(node);
+            }}
+            className={cn(isDragging && "opacity-60", className)}
+        >
+            <DashboardApplyCard {...props} />
+        </div>
+    );
+};

--- a/src/features/dashboard/dnd/DndApplySection.tsx
+++ b/src/features/dashboard/dnd/DndApplySection.tsx
@@ -1,0 +1,78 @@
+import { useCallback } from "react";
+import { useDrop } from "react-dnd";
+
+import { DashboardApplyWrapper } from "@/features/dashboard/components/DashboardApply";
+import {
+    SECTION_ORDER,
+    DND_ITEM_TYPES,
+    type Section,
+    type DragItem,
+} from "@/features/dashboard/dnd/types";
+
+export interface DndApplySectionProps extends Omit<React.ComponentProps<"div">, "onDrop" | "ref"> {
+    title: string;
+    value: number;
+    wrapperClassName?: string;
+    sectionKey: Section;
+    sectionIndex: number;
+    maxStep?: 1 | 2;
+    onCardDrop: (item: DragItem) => void;
+    children?: React.ReactNode;
+}
+
+export const DndApplySection = ({
+    title,
+    value,
+    wrapperClassName,
+    sectionIndex,
+    maxStep = 2,
+    onCardDrop,
+    children,
+    className,
+    ...props
+}: DndApplySectionProps) => {
+    const [{ isOver, canDrop }, dropRef] = useDrop<
+        DragItem,
+        void,
+        { isOver: boolean; canDrop: boolean }
+    >(
+        () => ({
+            accept: DND_ITEM_TYPES.APPLY_CARD,
+            canDrop: (item) => {
+                const from = SECTION_ORDER.indexOf(item.from);
+                const diff = sectionIndex - from;
+                return diff !== 0 && Math.abs(diff) <= maxStep;
+            },
+            drop: (item) => {
+                onCardDrop(item);
+            },
+            collect: (monitor) => ({
+                isOver: monitor.isOver({ shallow: true }),
+                canDrop: monitor.canDrop(),
+            }),
+        }),
+        [sectionIndex, maxStep, onCardDrop],
+    );
+
+    const setDropRef = useCallback(
+        (node: HTMLDivElement | null) => {
+            dropRef(node);
+        },
+        [dropRef],
+    );
+
+    return (
+        <div className={className} {...props}>
+            <DashboardApplyWrapper
+                title={title}
+                value={value}
+                wrapperClassName={wrapperClassName}
+                droppableRef={setDropRef}
+                isOver={isOver}
+                canDrop={canDrop}
+            >
+                {children}
+            </DashboardApplyWrapper>
+        </div>
+    );
+};

--- a/src/features/dashboard/dnd/constants/constants.ts
+++ b/src/features/dashboard/dnd/constants/constants.ts
@@ -1,0 +1,8 @@
+import type { Section } from "@/features/dashboard/dnd/types";
+
+export const sectionState: Record<Section, { title: string; wrapperClassName: string }> = {
+    planned: { title: "지원 예정", wrapperClassName: "bg-zinc-50" },
+    writing: { title: "서류 작성 중", wrapperClassName: "bg-yellow-50" },
+    submitted: { title: "제출 완료", wrapperClassName: "bg-sky-50" },
+    interview: { title: "면접 진행", wrapperClassName: "bg-green-50" },
+};

--- a/src/features/dashboard/dnd/hooks/useBoardState.ts
+++ b/src/features/dashboard/dnd/hooks/useBoardState.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback } from "react";
+
+import type { Section, ApplyCard, DragItem } from "@/features/dashboard/dnd/types";
+
+export const useBoardState = (initialBoard: Record<Section, ApplyCard[]>) => {
+    const [board, setBoard] = useState<Record<Section, ApplyCard[]>>(initialBoard);
+
+    const moveTo = useCallback((dragItem: DragItem, toSection: Section) => {
+        setBoard((previousBoard) => {
+            if (dragItem.from === toSection) return previousBoard;
+
+            const nextBoard = { ...previousBoard } as Record<Section, ApplyCard[]>;
+            const sourceCards = [...nextBoard[dragItem.from]];
+            const sourceIndex = sourceCards.findIndex((card) => card.id === dragItem.id);
+            if (sourceIndex === -1) return previousBoard;
+
+            const [movedCard] = sourceCards.splice(sourceIndex, 1);
+            const targetCards = [...nextBoard[toSection], movedCard];
+
+            nextBoard[dragItem.from] = sourceCards;
+            nextBoard[toSection] = targetCards;
+
+            return nextBoard;
+        });
+    }, []);
+
+    return { board, setBoard, moveTo };
+};

--- a/src/features/dashboard/dnd/index.ts
+++ b/src/features/dashboard/dnd/index.ts
@@ -1,0 +1,2 @@
+export * from "./DndApplyCard";
+export * from "./DndApplySection";

--- a/src/features/dashboard/dnd/mocks/sectionMock.ts
+++ b/src/features/dashboard/dnd/mocks/sectionMock.ts
@@ -1,0 +1,40 @@
+import type { Section, ApplyCard } from "@/features/dashboard/dnd/types";
+
+export const sectionMock: Record<Section, ApplyCard[]> = {
+    planned: [
+        {
+            id: "c1",
+            icon: undefined,
+            company: "LG CNS",
+            position: "클라우드 엔지니어",
+            dday: "D-14",
+        },
+    ],
+    writing: [
+        {
+            id: "c2",
+            icon: undefined,
+            company: "삼성전자",
+            position: "DX부문 소프트웨어 개발",
+            dday: "D-7",
+        },
+    ],
+    submitted: [
+        {
+            id: "c3",
+            icon: undefined,
+            company: "네이버",
+            position: "백엔드 개발자",
+            dday: "D-3",
+        },
+    ],
+    interview: [
+        {
+            id: "c4",
+            icon: undefined,
+            company: "카카오",
+            position: "프론트엔드 개발자",
+            dday: "D-21",
+        },
+    ],
+};

--- a/src/features/dashboard/dnd/types.ts
+++ b/src/features/dashboard/dnd/types.ts
@@ -1,0 +1,18 @@
+import type { DashboardApplyCardProps } from "@/features/dashboard/components/DashboardApply";
+
+export const DND_ITEM_TYPES = {
+    APPLY_CARD: "APPLY_CARD",
+} as const;
+
+export type Section = "planned" | "writing" | "submitted" | "interview";
+
+export type ApplyCard = { id: string } & DashboardApplyCardProps;
+
+export interface DragItem {
+    type: typeof DND_ITEM_TYPES.APPLY_CARD;
+    id: string;
+    from: Section;
+    origin: number;
+}
+
+export const SECTION_ORDER: Section[] = ["planned", "writing", "submitted", "interview"];

--- a/src/pages/mentee/MenteeDashboardPage.tsx
+++ b/src/pages/mentee/MenteeDashboardPage.tsx
@@ -1,111 +1,119 @@
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
 import { Folder, UserRoundPen, Clock3, UserRound } from "lucide-react";
 
 import { NewApplicationButton } from "@/features/applications/components/applications-create";
-import {
-    DashboardApplyCard,
-    DashboardApplyWrapper,
-    DashboardApplyContainer,
-} from "@/features/dashboard/components/DashboardApply";
+import { DashboardApplyContainer } from "@/features/dashboard/components/DashboardApply";
 import {
     DashboardHeaderContainer,
     DashboardHeaderCard,
 } from "@/features/dashboard/components/DashboardHeader";
+import { DndApplyCard, DndApplySection } from "@/features/dashboard/dnd";
+import { sectionState } from "@/features/dashboard/dnd/constants/constants";
+import { useBoardState } from "@/features/dashboard/dnd/hooks/useBoardState";
+import { sectionMock } from "@/features/dashboard/dnd/mocks/sectionMock";
+import { SECTION_ORDER } from "@/features/dashboard/dnd/types";
 
 //TODO : 기업 이미지 불러오기
 const PlaceholderLogo: React.ReactNode = <div className="h-5 w-5 rounded-sm bg-zinc-200/80" />;
 
 export default function MenteeDashboardPage() {
+    const { board, moveTo } = useBoardState(sectionMock);
+    const totalApplications = Object.values(board).reduce(
+        (sum, sectionCards) => sum + sectionCards.length,
+        0,
+    );
+    const writing = board.writing.length;
+    const interview = board.interview.length;
+
     return (
-        <div className="px-6 py-6">
-            <div className="flex items-start justify-between">
-                <div>
-                    <h1 className="text-xl font-semibold text-foreground">취업 트래커 대시보드</h1>
-                    <h2 className="mt-1 text-sm leading-[22px] text-[#485563] font-normal">
-                        모든 취업 활동을 한눈에 관리하세요
-                    </h2>
+        <DndProvider backend={HTML5Backend}>
+            <div className="px-6 py-6">
+                <div className="flex items-start justify-between">
+                    <div>
+                        <h1 className="text-xl font-semibold text-foreground">
+                            취업 트래커 대시보드
+                        </h1>
+                        <h2 className="mt-1 text-sm leading-[22px] text-[#485563] font-normal">
+                            모든 취업 활동을 한눈에 관리하세요
+                        </h2>
+                    </div>
+                    <NewApplicationButton
+                        onClick={() => {
+                            //TODO: 나중에 모달 오픈 훅 연결 예정
+                            alert("신규 지원 추가 클릭");
+                        }}
+                    />
                 </div>
-                <NewApplicationButton
-                    onClick={() => {
-                        //TODO: 나중에 모달 오픈 훅 연결 예정
-                        alert("신규 지원 추가 클릭");
-                    }}
-                />
+
+                <DashboardHeaderContainer className="mt-4">
+                    <DashboardHeaderCard
+                        title="전체 지원 패키지"
+                        value={totalApplications}
+                        description="+2 이번 주"
+                        icon={<Folder className="h-5 w-5 text-blue-600" strokeWidth={2} />}
+                        iconBg="bg-blue-50"
+                    />
+                    <DashboardHeaderCard
+                        title="진행 중인 멘토링"
+                        value={writing}
+                        description="+1 이번 주"
+                        icon={<UserRoundPen className="h-5 w-5 text-emerald-600" strokeWidth={2} />}
+                        iconBg="bg-emerald-50"
+                    />
+                    <DashboardHeaderCard
+                        title="이번 주 마감"
+                        value={2}
+                        description=" - "
+                        icon={<Clock3 className="h-5 w-5 text-orange-600" strokeWidth={2} />}
+                        iconBg="bg-orange-50"
+                    />
+                    <DashboardHeaderCard
+                        title="면접 대기"
+                        value={interview}
+                        description="+1 이번 주"
+                        icon={<UserRound className="h-5 w-5 text-violet-600" strokeWidth={2} />}
+                        iconBg="bg-violet-50"
+                    />
+                </DashboardHeaderContainer>
+
+                <h3 className="mt-8 mb-3 text-lg leading-7 font-semibold text-slate-900">
+                    지원 현황
+                </h3>
+
+                <DashboardApplyContainer>
+                    {SECTION_ORDER.map((sectionKey, sectionIndex) => {
+                        const section = sectionState[sectionKey];
+                        const cards = board[sectionKey];
+                        return (
+                            <DndApplySection
+                                key={sectionKey}
+                                title={section.title}
+                                value={cards.length}
+                                wrapperClassName={section.wrapperClassName}
+                                sectionKey={sectionKey}
+                                sectionIndex={sectionIndex}
+                                maxStep={2}
+                                onCardDrop={(item) => moveTo(item, sectionKey)}
+                            >
+                                {cards.map((card, cardIndex) => (
+                                    <DndApplyCard
+                                        key={card.id}
+                                        id={card.id}
+                                        from={sectionKey}
+                                        origin={cardIndex}
+                                        icon={PlaceholderLogo}
+                                        company={card.company}
+                                        position={card.position}
+                                        dday={card.dday}
+                                    />
+                                ))}
+                            </DndApplySection>
+                        );
+                    })}
+                </DashboardApplyContainer>
             </div>
-
-            <DashboardHeaderContainer className="mt-4">
-                <DashboardHeaderCard
-                    title="전체 지원 패키지"
-                    value={12}
-                    description="+2 이번 주"
-                    icon={<Folder className="h-5 w-5 text-blue-600" strokeWidth={2} />}
-                    iconBg="bg-blue-50"
-                />
-                <DashboardHeaderCard
-                    title="진행 중인 멘토링"
-                    value={3}
-                    description="+1 이번 주"
-                    icon={<UserRoundPen className="h-5 w-5 text-emerald-600" strokeWidth={2} />}
-                    iconBg="bg-emerald-50"
-                />
-                <DashboardHeaderCard
-                    title="이번 주 마감"
-                    value={2}
-                    description=" - "
-                    icon={<Clock3 className="h-5 w-5 text-orange-600" strokeWidth={2} />}
-                    iconBg="bg-orange-50"
-                />
-                <DashboardHeaderCard
-                    title="면접 대기"
-                    value={1}
-                    description="+1 이번 주"
-                    icon={<UserRound className="h-5 w-5 text-violet-600" strokeWidth={2} />}
-                    iconBg="bg-violet-50"
-                />
-            </DashboardHeaderContainer>
-
-            <h3 className="mt-8 mb-3 text-lg leading-7 font-semibold text-slate-900">지원 현황</h3>
-
-            <DashboardApplyContainer>
-                <DashboardApplyWrapper title="지원 예정" value={1} wrapperClassName="bg-zinc-50">
-                    <DashboardApplyCard
-                        icon={PlaceholderLogo}
-                        company="LG CNS"
-                        position="클라우드 엔지니어"
-                        dday="D-14"
-                    />
-                </DashboardApplyWrapper>
-
-                <DashboardApplyWrapper
-                    title="서류 작성 중"
-                    value={1}
-                    wrapperClassName="bg-yellow-50"
-                >
-                    <DashboardApplyCard
-                        icon={PlaceholderLogo}
-                        company="삼성전자"
-                        position="DX부문 소프트웨어 개발"
-                        dday="D-7"
-                    />
-                </DashboardApplyWrapper>
-
-                <DashboardApplyWrapper title="제출 완료" value={1} wrapperClassName="bg-sky-50">
-                    <DashboardApplyCard
-                        icon={PlaceholderLogo}
-                        company="네이버"
-                        position="백엔드 개발자"
-                        dday="D-3"
-                    />
-                </DashboardApplyWrapper>
-
-                <DashboardApplyWrapper title="면접 진행" value={1} wrapperClassName="bg-green-50">
-                    <DashboardApplyCard
-                        icon={PlaceholderLogo}
-                        company="카카오"
-                        position="프론트엔드 개발자"
-                        dday="D-21"
-                    />
-                </DashboardApplyWrapper>
-            </DashboardApplyContainer>
-        </div>
+        </DndProvider>
     );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,6 +154,11 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/runtime@^7.9.2":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
+  integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
+
 "@babel/template@^7.27.2":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
@@ -957,6 +962,21 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.1.tgz#78244efe12930c56fd255d7923865857c41ac8cb"
   integrity sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==
+
+"@react-dnd/asap@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
+  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
+
+"@react-dnd/invariant@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-4.0.2.tgz#b92edffca10a26466643349fac7cdfb8799769df"
+  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
+
+"@react-dnd/shallowequal@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
+  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
 
 "@rolldown/pluginutils@1.0.0-beta.32":
   version "1.0.0-beta.32"
@@ -1926,6 +1946,15 @@ detect-node-es@^1.1.0:
   resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
+dnd-core@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-16.0.1.tgz#a1c213ed08961f6bd1959a28bb76f1a868360d19"
+  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
+  dependencies:
+    "@react-dnd/asap" "^5.0.1"
+    "@react-dnd/invariant" "^4.0.1"
+    redux "^4.2.0"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -2431,6 +2460,13 @@ headers-polyfill@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-4.0.3.tgz#922a0155de30ecc1f785bcf04be77844ca95ad07"
   integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
+
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 html-encoding-sniffer@^4.0.0:
   version "4.0.0"
@@ -3157,6 +3193,24 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+react-dnd-html5-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
+  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+  dependencies:
+    dnd-core "^16.0.1"
+
+react-dnd@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
+  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
+  dependencies:
+    "@react-dnd/invariant" "^4.0.1"
+    "@react-dnd/shallowequal" "^4.0.1"
+    dnd-core "^16.0.1"
+    fast-deep-equal "^3.1.3"
+    hoist-non-react-statics "^3.3.2"
+
 react-docgen-typescript@^2.2.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz#033428b4a6a639d050ac8baf2a5195c596521713"
@@ -3189,6 +3243,11 @@ react-hook-form@^7.62.0:
   version "7.62.0"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.62.0.tgz#2d81e13c2c6b6d636548e440818341ca753218d0"
   integrity sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==
+
+react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-pdf@^10.1.0:
   version "10.1.0"
@@ -3274,6 +3333,13 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## ✅ Linked Issue

- #24

## 🔍 What I did

- react-dnd로 ApplyCard를 Drag하고 섹션에 Drop하는 것을 구현했습니다.
- Drop을 할때 양방향으로 이동할 수 있도록 했고 maxStep을 2로 제한했습니다.
- DnD 레이어를 source와 target으로 관심사 분리했습니다. (DndApplyCard, DndApplySection)
- useBoardState 훅을 만들어서 상태변경(moveTo)만 수행하도록 했고, DnD 컴포넌트는 직접 상태를 바꾸지 않고 변경이 필요할때만 이벤트를 전달하도록 했습니다.

## 💡 Why I did it

- 지난 기술멘토링때 멘토님께서 설명해주셨던 react-dnd 작동방식을 깃허브로 확인하니 monitor가
1. 좌표(x,y)를 줘서 절대위치 결정 (getClientOffset(), getInitialClientOffset() 등)
2. 시작점 대비 변화량을 계산한 상태를 업데이트 (getDifferenceFromInitialOffset() 등)

크게 2가지로 제공하는 걸 알게 되었습니다. 그런데 이번 스프린트에서 핵심이 칸반보드 섹션 간 이동이어서 좌표없이 섹션 인덱스차만으로 충분할 것 같았습니다. 그래서 DragItem의 원점 정보(from, origin)와 SECTION_ORDER를 사용해서 섹션 인덱스 차로 state를 옮겼습니다.

- 그리고 보통 라이브러리는 이벤트를 외부에서 처리한다고 들어 Drop에서 직접 상태변경을 하는게 아니라 useBoardState의 moveTo에서 진행하도록 했습니다.
- 파라미터도 최소화해서 의도를 명확하게 했습니다. (id(식별), from(원점 섹션), origin(원래 인덱스))


## 🔧 Additional context(궁금한 점)

1. 고도화할만한 요소가 있을지 ?
DnD 라이브러리르 직접 구현하기 위해서 react-dnd를 사용해봤는데 아직 핵심 기능을 충분히 못 써본거 같은 느낌이 들었습니다. 그래서 고도화를 생각해봤는데
같은 섹션 내에서 순서 변경 필요할때 getClientOffset()나 getDifferenceFromInitialOffset(), getBoundingClientRect()조합을 쓰면 될 것 같은데 대시보드의 역할상 순서변경이 필요한가에 대한 의문이 듭니다. (마감기한으로 정렬하는 것이 좋다고 생각했습니다.) 혹시 제가 아직 활용해보지 못했지만, 추가적으로 시도해볼 만한 핵심 기능이나 구현하면서 겪을 수 있는 불편한점이 있을까요?

2. useDrag를 사용해보니 뭔가 Redux와 비슷한 것 같아 찾아보니 실제로 내부적으로 Redux를 쓰는 것으로 확인했습니다. 
- react-dnd가 내부 상태를 관리하고, collect로 필요한 값만 선택해서 컴포넌트를 다시 그린다고 이해했는데, 제 이해가 맞을지 궁금합니다. 또 collect는 어느 정도로 최소화하면 좋을지?도 궁금합니다.


3. html5 DnD backend API를 같이 사용하는 이유에 대해 궁금해서 찾아보니 react-dnd가 코어와 백엔드를 분리해둔 구조라서 브라우저 입력 이벤트를 dnd-core로 연결해주는 용도로 사용하는 것을 알게 되었습니다. 그런데 단점도 적지 않더라구요 (dragover는 기본 동작 방지를 위한 이벤트로만 보인다 / 브라우저간 편차 심하다 등) 그래서 직접 구현할때
HTML5 DnD API 기반으로 가는 것이 현실적일지, 아니면 mouse등의 이벤트로 직접 처리하는 방식이 더 나을지 궁금합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 멘티 대시보드에 드래그앤드롭 보드 도입: 카드 섹션 간 이동 지원
  - 섹션별 상태(지원 예정/서류 작성 중/제출 완료/면접 진행)와 색상 테마 적용
  - 드래그 중 가능/불가 시각적 피드백 제공
  - 전체 지원 건수 자동 집계 및 섹션별 카운트 반영
  - 새 지원 추가 버튼 추가(동작 준비 중)
- Refactor
  - 대시보드 레이아웃을 DnD 중심으로 재구성
- Chores
  - 드래그앤드롭 관련 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->