### PR TITLE
Feature#31 [김대건] 코멘트 관련 컴포넌트 구현 및 영역선택 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.85.5",
     "axios": "^1.11.0",

--- a/src/@types/vec.d.ts
+++ b/src/@types/vec.d.ts
@@ -1,0 +1,4 @@
+declare type Vector2d = {
+    x: number;
+    y: number;
+};

--- a/src/app/styles/main.css
+++ b/src/app/styles/main.css
@@ -117,4 +117,10 @@
     body {
         @apply bg-background text-foreground;
     }
+    .no-drag {
+        -webkit-user-drag: none;
+        -khtml-user-drag: none;
+        -moz-user-drag: none;
+        -o-user-drag: none;
+    }
 }

--- a/src/app/ui/NavAside.tsx
+++ b/src/app/ui/NavAside.tsx
@@ -8,7 +8,7 @@ export interface NavAsideProps {
 
 export const NavAside = ({ navAsideMenus }: NavAsideProps) => {
     return (
-        <aside className="w-[210px] shadow-xs h-full flex-shrink-0 p-4">
+        <aside className="w-[210px] shadow-xs h-full flex-shrink-0 p-4 border-r border-gray-200">
             <nav className="w-full flex flex-col gap-3">
                 {navAsideMenus.map((menu) => {
                     return <NavAsideItem key={menu.to} {...menu} />;

--- a/src/core/document-commenter/components/Comment/CommentArea.stories.tsx
+++ b/src/core/document-commenter/components/Comment/CommentArea.stories.tsx
@@ -1,0 +1,22 @@
+import { CommentArea } from "@/core/document-commenter/components/Comment/CommentArea";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof CommentArea> = {
+    component: CommentArea,
+};
+
+export default meta;
+type Story = StoryObj<typeof CommentArea>;
+
+export const Default: Story = {
+    args: {
+        id: 1,
+        startX: 50,
+        startY: 50,
+        endX: 200,
+        endY: 100,
+        content: "This is a comment",
+        borderColor: "#F6B13B",
+        backgroundColor: "#F6B13B33",
+    },
+};

--- a/src/core/document-commenter/components/Comment/CommentArea.tsx
+++ b/src/core/document-commenter/components/Comment/CommentArea.tsx
@@ -1,0 +1,66 @@
+import type { CSSProperties } from "react";
+
+import type { Comment } from "@/core/document-commenter/models/Comment";
+
+export interface CommentAreaProps extends Comment {
+    // TODO : CommentAreaPlaceholder와 통합 고려
+    // type: "placeholder" | "comment";
+
+    borderColor: CSSProperties["borderColor"];
+    backgroundColor: CSSProperties["backgroundColor"];
+
+    style: CSSProperties;
+}
+
+export const CommentArea = ({
+    // type,
+    // content,
+
+    id,
+
+    startX,
+    startY,
+    endX,
+    endY,
+
+    borderColor,
+    backgroundColor,
+}: CommentAreaProps) => {
+    return (
+        <mark
+            style={{
+                position: "absolute",
+                top: startY,
+                left: startX,
+                width: endX - startX,
+                height: endY - startY,
+
+                backgroundColor: backgroundColor,
+                border: `2px solid ${borderColor}`,
+                pointerEvents: "none",
+                cursor: "pointer",
+            }}
+        >
+            <div
+                style={{
+                    position: "absolute",
+                    top: "-10px",
+                    right: "-10px",
+                    borderRadius: "50%",
+                    backgroundColor: borderColor,
+                    width: "20px",
+                    height: "20px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: "12px",
+                    fontWeight: "bold",
+                    color: "white",
+                    pointerEvents: "auto",
+                }}
+            >
+                {id}
+            </div>
+        </mark>
+    );
+};

--- a/src/core/document-commenter/components/Comment/CommentAreaPlaceholder.stories.tsx
+++ b/src/core/document-commenter/components/Comment/CommentAreaPlaceholder.stories.tsx
@@ -1,0 +1,22 @@
+import { CommentAreaPlaceholder } from "@/core/document-commenter/components/Comment/CommentAreaPlaceholder";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof CommentAreaPlaceholder> = {
+    component: CommentAreaPlaceholder,
+};
+
+export default meta;
+type Story = StoryObj<typeof CommentAreaPlaceholder>;
+
+export const Default: Story = {
+    args: {
+        borderColor: "#F6B13B",
+        backgroundColor: "#F6B13B33",
+        style: {
+            top: 50,
+            left: 50,
+            width: 200,
+            height: 100,
+        },
+    },
+};

--- a/src/core/document-commenter/components/Comment/CommentAreaPlaceholder.tsx
+++ b/src/core/document-commenter/components/Comment/CommentAreaPlaceholder.tsx
@@ -1,0 +1,24 @@
+import { type CSSProperties } from "react";
+
+export interface CommentAreaPlaceholderProps {
+    borderColor: CSSProperties["borderColor"];
+    backgroundColor: CSSProperties["backgroundColor"];
+    style: CSSProperties;
+}
+
+export const CommentAreaPlaceholder = ({
+    style,
+    borderColor,
+    backgroundColor,
+}: CommentAreaPlaceholderProps) => {
+    return (
+        <mark
+            style={{
+                position: "absolute",
+                border: `1px dashed ${borderColor}`,
+                backgroundColor,
+                ...style,
+            }}
+        />
+    );
+};

--- a/src/core/document-commenter/components/Comment/index.tsx
+++ b/src/core/document-commenter/components/Comment/index.tsx
@@ -1,0 +1,2 @@
+export * from "./CommentArea";
+export * from "./CommentAreaPlaceholder";

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbar.stories.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbar.stories.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from "react/jsx-runtime";
+
 import { MessageSquarePlus, ZoomIn, ZoomOut } from "lucide-react";
 
 import { CommentToolbar } from "@/core/document-commenter/components/CommentToolbar/CommentToolbar";
@@ -28,7 +30,7 @@ export const Default: Story = {
             />,
         ],
         rightItems: [
-            <div className="flex gap-1 h-full">
+            <Fragment>
                 <CommentToolbarButtonItem
                     className="h-full w-5"
                     icon={<ZoomIn size={16} />}
@@ -41,7 +43,7 @@ export const Default: Story = {
                     tooltip="축소"
                     onClick={fn()}
                 />
-            </div>,
+            </Fragment>,
         ],
     },
 };

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbar.stories.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbar.stories.tsx
@@ -1,0 +1,47 @@
+import { MessageSquarePlus, ZoomIn, ZoomOut } from "lucide-react";
+
+import { CommentToolbar } from "@/core/document-commenter/components/CommentToolbar/CommentToolbar";
+import { CommentToolbarButtonItem } from "@/core/document-commenter/components/CommentToolbar/CommentToolbarButtonItem";
+import { CommentToolbarToggleItem } from "@/core/document-commenter/components/CommentToolbar/CommentToolbarToggleItem";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+const meta: Meta<typeof CommentToolbar> = {
+    component: CommentToolbar,
+};
+
+export default meta;
+type Story = StoryObj<typeof CommentToolbar>;
+
+export const Default: Story = {
+    args: {
+        leftItems: [
+            <CommentToolbarToggleItem
+                icon={<MessageSquarePlus />}
+                tooltip="댓글 추가"
+                onToggle={fn()}
+            />,
+            <CommentToolbarToggleItem
+                icon={<MessageSquarePlus />}
+                tooltip="댓글 추가"
+                onToggle={fn()}
+            />,
+        ],
+        rightItems: [
+            <div className="flex gap-1 h-full">
+                <CommentToolbarButtonItem
+                    className="h-full w-5"
+                    icon={<ZoomIn size={16} />}
+                    tooltip="확대"
+                    onClick={fn()}
+                />
+                <CommentToolbarButtonItem
+                    className="h-full w-5"
+                    icon={<ZoomOut size={16} />}
+                    tooltip="축소"
+                    onClick={fn()}
+                />
+            </div>,
+        ],
+    },
+};

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbar.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbar.tsx
@@ -5,9 +5,13 @@ export interface CommentToolbarProps {
 
 export const CommentToolbar = ({ leftItems, rightItems }: CommentToolbarProps) => {
     return (
-        <nav className="bg-[#F9FAFB] w-full h-12 border-gray-300 flex justify-between px-2">
-            <ul className="w-full h-full flex items-center gap-0.5">{leftItems}</ul>
-            <ul className="w-full h-full flex items-center justify-end gap-0.5">{rightItems}</ul>
+        <nav className="bg-[#F9FAFB] w-full h-12 border-gray-200 border-b flex justify-between px-4">
+            <div className="w-full h-full flex items-center justify-start gap-0.5">
+                <ul className="flex gap-1 h-full">{leftItems}</ul>
+            </div>
+            <div className="w-full h-full flex items-center justify-end gap-0.5">
+                <ul className="flex gap-1 h-full">{rightItems}</ul>
+            </div>
         </nav>
     );
 };

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbar.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbar.tsx
@@ -5,7 +5,10 @@ export interface CommentToolbarProps {
 
 export const CommentToolbar = ({ leftItems, rightItems }: CommentToolbarProps) => {
     return (
-        <nav className="bg-[#F9FAFB] w-full h-12 border-gray-200 border-b flex justify-between px-4">
+        <nav
+            className="bg-[#F9FAFB] w-full h-12 border-gray-200 border-b flex justify-between px-4"
+            aria-label="댓글 툴바"
+        >
             <div className="w-full h-full flex items-center justify-start gap-0.5">
                 <ul className="flex gap-1 h-full">{leftItems}</ul>
             </div>

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbar.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbar.tsx
@@ -1,0 +1,13 @@
+export interface CommentToolbarProps {
+    leftItems?: React.ReactNode;
+    rightItems?: React.ReactNode;
+}
+
+export const CommentToolbar = ({ leftItems, rightItems }: CommentToolbarProps) => {
+    return (
+        <nav className="bg-[#F9FAFB] w-full h-12 border-gray-300 flex justify-between px-2">
+            <ul className="w-full h-full flex items-center gap-0.5">{leftItems}</ul>
+            <ul className="w-full h-full flex items-center justify-end gap-0.5">{rightItems}</ul>
+        </nav>
+    );
+};

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbarButtonItem.stories.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbarButtonItem.stories.tsx
@@ -1,0 +1,13 @@
+import { CommentToolbarButtonItem } from "@/core/document-commenter/components/CommentToolbar";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof CommentToolbarButtonItem> = {
+    component: CommentToolbarButtonItem,
+};
+
+export default meta;
+type Story = StoryObj<typeof CommentToolbarButtonItem>;
+
+export const Default: Story = {
+    args: {},
+};

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbarButtonItem.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbarButtonItem.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/shared/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+
+export interface CommentToolbarButtonItemProps {
+    icon: React.ReactNode;
+    tooltip: string;
+    className?: string;
+    onClick: () => void;
+}
+
+export const CommentToolbarButtonItem = ({
+    icon,
+    tooltip,
+    className,
+    onClick,
+}: CommentToolbarButtonItemProps) => {
+    return (
+        <li className="list-none">
+            <Tooltip delayDuration={1000}>
+                <TooltipTrigger asChild aria-label={tooltip}>
+                    <button
+                        className={cn(
+                            "aspect-square flex justify-center items-center cursor-pointer",
+                            className,
+                        )}
+                        onClick={onClick}
+                    >
+                        {icon}
+                    </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p>{tooltip}</p>
+                </TooltipContent>
+            </Tooltip>
+        </li>
+    );
+};

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbarToggleItem.stories.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbarToggleItem.stories.tsx
@@ -1,0 +1,20 @@
+import { MessageSquarePlus } from "lucide-react";
+
+import { CommentToolbarToggleItem } from "@/core/document-commenter/components/CommentToolbar";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+const meta: Meta<typeof CommentToolbarToggleItem> = {
+    component: CommentToolbarToggleItem,
+};
+
+export default meta;
+type Story = StoryObj<typeof CommentToolbarToggleItem>;
+
+export const Default: Story = {
+    args: {
+        icon: <MessageSquarePlus />,
+        tooltip: "댓글 추가",
+        onToggle: fn(),
+    },
+};

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbarToggleItem.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbarToggleItem.tsx
@@ -10,7 +10,7 @@ export interface CommentToolbarItemProps {
 
 export const CommentToolbarToggleItem = ({ icon, tooltip, onToggle }: CommentToolbarItemProps) => {
     return (
-        <li className="list-none">
+        <li className="list-none h-full flex items-center">
             <Tooltip delayDuration={1000}>
                 <TooltipTrigger asChild aria-label={tooltip}>
                     <Toggle

--- a/src/core/document-commenter/components/CommentToolbar/CommentToolbarToggleItem.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/CommentToolbarToggleItem.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/shared/lib/utils";
+import { Toggle } from "@/shared/ui/toggle";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/shared/ui/tooltip";
+
+export interface CommentToolbarItemProps {
+    icon: React.ReactNode;
+    tooltip: string;
+    onToggle: (value: boolean) => void;
+}
+
+export const CommentToolbarToggleItem = ({ icon, tooltip, onToggle }: CommentToolbarItemProps) => {
+    return (
+        <li className="list-none">
+            <Tooltip delayDuration={1000}>
+                <TooltipTrigger asChild aria-label={tooltip}>
+                    <Toggle
+                        onPressedChange={onToggle}
+                        className={cn(
+                            "hover:bg-gray-100 dark:hover:bg-gray-800",
+                            "[&[aria-pressed=true]]:!bg-blue-100 [&[aria-pressed=true]]:!text-blue-700",
+                            "dark:[&[aria-pressed=true]]:!bg-blue-900 dark:[&[aria-pressed=true]]:!text-blue-300",
+                        )}
+                    >
+                        {icon}
+                    </Toggle>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p>{tooltip}</p>
+                </TooltipContent>
+            </Tooltip>
+        </li>
+    );
+};

--- a/src/core/document-commenter/components/CommentToolbar/index.tsx
+++ b/src/core/document-commenter/components/CommentToolbar/index.tsx
@@ -1,0 +1,3 @@
+export * from "./CommentToolbar";
+export * from "./CommentToolbarButtonItem";
+export * from "./CommentToolbarToggleItem";

--- a/src/core/document-commenter/hooks/useAreaSelect.ts
+++ b/src/core/document-commenter/hooks/useAreaSelect.ts
@@ -1,0 +1,72 @@
+import { useCallback, useRef, useState, type CSSProperties } from "react";
+
+export interface AreaSelectionBoxStyle {
+    top: CSSProperties["top"];
+    left: CSSProperties["left"];
+    width: CSSProperties["width"];
+    height: CSSProperties["height"];
+}
+
+export const useAreaSelect = () => {
+    const rootElementRef = useRef<HTMLCanvasElement | null>(null);
+
+    const [isDragging, setIsDragging] = useState<boolean>(false);
+    const [startPosition, setStartPosition] = useState<Vector2d>({ x: 0, y: 0 });
+    const [endPosition, setEndPosition] = useState<Vector2d>({ x: 0, y: 0 });
+
+    const [areaSelectionBoxStyle, setAreaSelectionBoxStyle] =
+        useState<AreaSelectionBoxStyle | null>(null);
+
+    const handleMouseDown = useCallback((event: React.MouseEvent) => {
+        if (!rootElementRef.current) return;
+
+        event.preventDefault();
+
+        const rect = rootElementRef.current.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+
+        setStartPosition({ x, y });
+        setEndPosition({ x, y });
+        setIsDragging(true);
+    }, []);
+
+    const handleMouseMove = useCallback(
+        (event: React.MouseEvent) => {
+            if (!isDragging || !rootElementRef.current) return;
+
+            event.preventDefault();
+
+            const rect = rootElementRef.current.getBoundingClientRect();
+            const x = event.clientX - rect.left;
+            const y = event.clientY - rect.top;
+
+            setEndPosition({ x, y });
+
+            const top = Math.min(startPosition.y, y);
+            const left = Math.min(startPosition.x, x);
+            const width = Math.abs(startPosition.x - x);
+            const height = Math.abs(startPosition.y - y);
+
+            setAreaSelectionBoxStyle({ top, left, width, height });
+        },
+        [isDragging, startPosition],
+    );
+
+    const handleMouseUp = useCallback(() => {
+        setIsDragging(false);
+    }, []);
+
+    return {
+        rootElementRef,
+        isDragging,
+        areaSelectionBoxStyle,
+
+        startPosition,
+        endPosition,
+
+        handleMouseDown,
+        handleMouseMove,
+        handleMouseUp,
+    };
+};

--- a/src/core/document-commenter/hooks/useAreaSelect.ts
+++ b/src/core/document-commenter/hooks/useAreaSelect.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type CSSProperties } from "react";
+import { useCallback, useRef, useState, type CSSProperties, type MouseEvent } from "react";
 
 export interface AreaSelectionBoxStyle {
     top: CSSProperties["top"];
@@ -17,7 +17,7 @@ export const useAreaSelect = () => {
     const [areaSelectionBoxStyle, setAreaSelectionBoxStyle] =
         useState<AreaSelectionBoxStyle | null>(null);
 
-    const handleMouseDown = useCallback((event: React.MouseEvent) => {
+    const handleMouseDown = useCallback((event: MouseEvent) => {
         if (!rootElementRef.current) return;
 
         event.preventDefault();
@@ -32,7 +32,7 @@ export const useAreaSelect = () => {
     }, []);
 
     const handleMouseMove = useCallback(
-        (event: React.MouseEvent) => {
+        (event: MouseEvent) => {
             if (!isDragging || !rootElementRef.current) return;
 
             event.preventDefault();

--- a/src/core/document-commenter/models/Comment.ts
+++ b/src/core/document-commenter/models/Comment.ts
@@ -1,0 +1,9 @@
+export interface Comment {
+    id: number;
+    content: string;
+
+    startX: number;
+    startY: number;
+    endX: number;
+    endY: number;
+}

--- a/src/core/document-diff/integration/components/DiffViewer/PdfDiffViewer.tsx
+++ b/src/core/document-diff/integration/components/DiffViewer/PdfDiffViewer.tsx
@@ -10,6 +10,7 @@ export const PdfDiffViewer = ({ before, after }: PdfDiffViewerProps) => {
     return (
         <DiffLayout>
             <PdfViewer
+                viewerWidth="50%"
                 render={({ width, currentPage, initializePages }) => (
                     <Document
                         scale={1}
@@ -24,6 +25,7 @@ export const PdfDiffViewer = ({ before, after }: PdfDiffViewerProps) => {
                 )}
             />
             <PdfViewer
+                viewerWidth="50%"
                 render={({ width, currentPage, initializePages }) => (
                     <Document
                         scale={1}

--- a/src/core/document-viewer/components/DocumentViewer/PdfViewer.stories.tsx
+++ b/src/core/document-viewer/components/DocumentViewer/PdfViewer.stories.tsx
@@ -15,6 +15,7 @@ export const Default: Story = {
     render: () => {
         return (
             <PdfViewer
+                viewerWidth="600px"
                 render={({ width, currentPage, initializePages }) => (
                     <Document
                         scale={1}

--- a/src/core/document-viewer/components/DocumentViewer/PdfViewer.tsx
+++ b/src/core/document-viewer/components/DocumentViewer/PdfViewer.tsx
@@ -1,6 +1,7 @@
-import type { CSSProperties } from "react";
+import { forwardRef, type CSSProperties } from "react";
 
 import { useDebouncedResizeObserver } from "@/shared/hooks/useDebouncedResizeObserver";
+import { cn } from "@/shared/lib/utils";
 
 import { PdfPageController } from "@/core/document-viewer/components/DocumentController";
 import {
@@ -43,21 +44,30 @@ export const PdfRenderer = ({ width, height, render }: PdfRendererProps) => {
     });
 };
 
-export interface DocumentViewerProps {
+export interface DocumentViewerProps extends React.ComponentPropsWithoutRef<"article"> {
     viewerWidth: CSSProperties["width"];
     debouncedTimeout?: number;
     render: (props: PdfViewerRenderProps) => React.ReactNode;
 }
 
-export const PdfViewer = ({ viewerWidth, debouncedTimeout = 400, render }: DocumentViewerProps) => {
-    const { ref, width, height } = useDebouncedResizeObserver(debouncedTimeout);
+export const PdfViewer = forwardRef<HTMLDivElement, DocumentViewerProps>(
+    ({ viewerWidth, debouncedTimeout = 400, render, ...props }: DocumentViewerProps) => {
+        const { ref, width, height } = useDebouncedResizeObserver(debouncedTimeout);
 
-    return (
-        <PdfPageContextProvider>
-            <article className="relative" ref={ref} style={{ width: viewerWidth }}>
-                <PdfPageController />
-                <PdfRenderer render={render} width={width} height={height} />
-            </article>
-        </PdfPageContextProvider>
-    );
-};
+        return (
+            <PdfPageContextProvider>
+                <article
+                    ref={ref}
+                    style={{ width: viewerWidth }}
+                    className={cn("relative", props.className)}
+                    {...props}
+                >
+                    <PdfPageController />
+                    <PdfRenderer render={render} width={width} height={height} />
+                </article>
+            </PdfPageContextProvider>
+        );
+    },
+);
+
+PdfViewer.displayName = "PdfViewer";

--- a/src/core/document-viewer/components/DocumentViewer/PdfViewer.tsx
+++ b/src/core/document-viewer/components/DocumentViewer/PdfViewer.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 import { useDebouncedResizeObserver } from "@/shared/hooks/useDebouncedResizeObserver";
 
 import { PdfPageController } from "@/core/document-viewer/components/DocumentController";
@@ -42,16 +44,17 @@ export const PdfRenderer = ({ width, height, render }: PdfRendererProps) => {
 };
 
 export interface DocumentViewerProps {
+    viewerWidth: CSSProperties["width"];
     debouncedTimeout?: number;
     render: (props: PdfViewerRenderProps) => React.ReactNode;
 }
 
-export const PdfViewer = ({ debouncedTimeout = 400, render }: DocumentViewerProps) => {
+export const PdfViewer = ({ viewerWidth, debouncedTimeout = 400, render }: DocumentViewerProps) => {
     const { ref, width, height } = useDebouncedResizeObserver(debouncedTimeout);
 
     return (
         <PdfPageContextProvider>
-            <article className="w-[50%] relative" ref={ref}>
+            <article className="relative" ref={ref} style={{ width: viewerWidth }}>
                 <PdfPageController />
                 <PdfRenderer render={render} width={width} height={height} />
             </article>

--- a/src/pages/mentee/MenteeFeedbackPage.tsx
+++ b/src/pages/mentee/MenteeFeedbackPage.tsx
@@ -1,0 +1,46 @@
+import { FileUser } from "lucide-react";
+
+import { Tab, TabNavItem } from "@/shared/components/Tab";
+import { TabItem } from "@/shared/components/Tab/TabItem";
+import { TabMenuIndicator } from "@/shared/components/Tab/TabMenuIndicator";
+import { TabNavBar } from "@/shared/components/Tab/TabNavBar";
+
+import { PortfolioFeedbackWidget } from "@/widgets/document-feedback/PortfolioFeedbackWidget";
+
+import { DocumentEventBusProvider } from "@/core/document-event/contexts/DocumentEventBusProvider";
+
+export default function MenteeFeedbackPage() {
+    return (
+        <DocumentEventBusProvider>
+            <Tab defaultActiveTab="이력서">
+                <TabNavBar>
+                    <TabNavItem
+                        icon={<FileUser size={16} />}
+                        label="이력서"
+                        indicator={<TabMenuIndicator value={0} />}
+                    />
+                    <TabNavItem
+                        icon={<FileUser size={16} />}
+                        label="포트폴리오"
+                        indicator={<TabMenuIndicator value={0} />}
+                    />
+                    <TabNavItem
+                        icon={<FileUser size={16} />}
+                        label="자기소개서"
+                        indicator={<TabMenuIndicator value={0} />}
+                    />
+                </TabNavBar>
+
+                <TabItem menu="이력서">
+                    <div>이력서 피드백 위젯</div>
+                </TabItem>
+                <TabItem menu="포트폴리오">
+                    <PortfolioFeedbackWidget />
+                </TabItem>
+                <TabItem menu="자기소개서">
+                    <div>자기소개서 피드백 위젯</div>
+                </TabItem>
+            </Tab>
+        </DocumentEventBusProvider>
+    );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,6 +9,7 @@ import { RootLayout } from "@/app/layouts/RootLayout";
 
 import HomePage from "@/pages/HomePage";
 import MenteeDashboardPage from "@/pages/mentee/MenteeDashboardPage";
+import MenteeFeedbackPage from "@/pages/mentee/MenteeFeedbackPage";
 import MenteeSearchMentorPage from "@/pages/mentee/MenteeSearchMentorPage";
 import MenteeSettingsPage from "@/pages/mentee/MenteeSettingsPage";
 import ApplicationDetailPage from "@/pages/mentee/applications/ApplicationDetailPage";
@@ -38,6 +39,8 @@ const routes = createRoutesFromElements(
                     <Route path="resumes" element={<ApplicationDetailPage />} />
                     <Route path="diff" element={<DocumentDiffPage />} />
                 </Route>
+
+                <Route path="feedback/:id" element={<MenteeFeedbackPage />} />
             </Route>
         </Route>
     </Fragment>,

--- a/src/shared/components/Helper/DisableSelection.tsx
+++ b/src/shared/components/Helper/DisableSelection.tsx
@@ -3,16 +3,18 @@ export interface DisableSelectionProps extends React.ComponentPropsWithoutRef<"d
 }
 
 export const DisableSelection = ({ children, ...props }: DisableSelectionProps) => {
+    const { style, ...rest } = props;
+
     return (
         <div
+            {...rest}
             style={{
                 userSelect: "none",
                 WebkitUserSelect: "none",
                 MozUserSelect: "none",
                 msUserSelect: "none",
-                ...props.style,
+                ...style,
             }}
-            {...props}
         >
             {children}
         </div>

--- a/src/shared/components/Helper/DisableSelection.tsx
+++ b/src/shared/components/Helper/DisableSelection.tsx
@@ -1,0 +1,20 @@
+export interface DisableSelectionProps extends React.ComponentPropsWithoutRef<"div"> {
+    children?: React.ReactNode;
+}
+
+export const DisableSelection = ({ children, ...props }: DisableSelectionProps) => {
+    return (
+        <div
+            style={{
+                userSelect: "none",
+                WebkitUserSelect: "none",
+                MozUserSelect: "none",
+                msUserSelect: "none",
+                ...props.style,
+            }}
+            {...props}
+        >
+            {children}
+        </div>
+    );
+};

--- a/src/shared/components/Helper/index.tsx
+++ b/src/shared/components/Helper/index.tsx
@@ -1,0 +1,1 @@
+export * from "./DisableSelection";

--- a/src/shared/hooks/useToggle.ts
+++ b/src/shared/hooks/useToggle.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from "react";
+
+export const useToggle = (initialValue: boolean = false) => {
+    const [value, setValue] = useState<boolean>(initialValue);
+
+    const toggle = useCallback(() => {
+        setValue((prev) => !prev);
+    }, []);
+
+    return [value, toggle] as const;
+};

--- a/src/shared/ui/toggle.tsx
+++ b/src/shared/ui/toggle.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/shared/lib/utils";
+
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+
+const toggleVariants = cva(
+    "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+    {
+        variants: {
+            variant: {
+                default: "bg-transparent",
+                outline:
+                    "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+            },
+            size: {
+                default: "h-9 px-2 min-w-9",
+                sm: "h-8 px-1.5 min-w-8",
+                lg: "h-10 px-2.5 min-w-10",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
+    },
+);
+
+function Toggle({
+    className,
+    variant,
+    size,
+    ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) {
+    return (
+        <TogglePrimitive.Root
+            data-slot="toggle"
+            className={cn(toggleVariants({ variant, size, className }))}
+            {...props}
+        />
+    );
+}
+
+export { Toggle, toggleVariants };

--- a/src/shared/ui/tooltip.tsx
+++ b/src/shared/ui/tooltip.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+
+import { cn } from "@/shared/lib/utils";
+
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+function TooltipProvider({
+    delayDuration = 0,
+    ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+    return (
+        <TooltipPrimitive.Provider
+            data-slot="tooltip-provider"
+            delayDuration={delayDuration}
+            {...props}
+        />
+    );
+}
+
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+    return (
+        <TooltipProvider>
+            <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+        </TooltipProvider>
+    );
+}
+
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+    return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+    className,
+    sideOffset = 0,
+    children,
+    ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+    return (
+        <TooltipPrimitive.Portal>
+            <TooltipPrimitive.Content
+                data-slot="tooltip-content"
+                sideOffset={sideOffset}
+                className={cn(
+                    "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+                    className,
+                )}
+                {...props}
+            >
+                {children}
+                <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+            </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+    );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/widgets/document-feedback/PortfolioFeedbackCommentToolbar.tsx
+++ b/src/widgets/document-feedback/PortfolioFeedbackCommentToolbar.tsx
@@ -1,0 +1,49 @@
+import { Fragment } from "react/jsx-runtime";
+
+import { MessageSquarePlus, ZoomIn, ZoomOut } from "lucide-react";
+
+import {
+    CommentToolbar,
+    CommentToolbarToggleItem,
+    CommentToolbarButtonItem,
+} from "@/core/document-commenter/components/CommentToolbar";
+
+export interface PortfolioFeedbackCommentToolbarWidgetProps {
+    onCommentModeToggle: () => void;
+    onZoomIn: () => void;
+    onZoomOut: () => void;
+}
+
+export const PortfolioFeedbackCommentToolbarWidget = ({
+    onCommentModeToggle,
+    onZoomIn,
+    onZoomOut,
+}: PortfolioFeedbackCommentToolbarWidgetProps) => {
+    return (
+        <CommentToolbar
+            leftItems={[
+                <CommentToolbarToggleItem
+                    tooltip="댓글 추가"
+                    icon={<MessageSquarePlus />}
+                    onToggle={onCommentModeToggle}
+                />,
+            ]}
+            rightItems={[
+                <Fragment>
+                    <CommentToolbarButtonItem
+                        tooltip="확대"
+                        className="h-full w-5"
+                        icon={<ZoomIn size={16} />}
+                        onClick={onZoomIn}
+                    />
+                    <CommentToolbarButtonItem
+                        tooltip="축소"
+                        className="h-full w-5"
+                        icon={<ZoomOut size={16} />}
+                        onClick={onZoomOut}
+                    />
+                </Fragment>,
+            ]}
+        />
+    );
+};

--- a/src/widgets/document-feedback/PortfolioFeedbackWidget.tsx
+++ b/src/widgets/document-feedback/PortfolioFeedbackWidget.tsx
@@ -1,0 +1,71 @@
+import { Fragment, useState } from "react";
+import { Document, Page } from "react-pdf";
+
+import { DisableSelection } from "@/shared/components/Helper/DisableSelection";
+import { useToggle } from "@/shared/hooks/useToggle";
+
+import { PortfolioFeedbackCommentToolbarWidget } from "@/widgets/document-feedback/PortfolioFeedbackCommentToolbar";
+
+import { CommentAreaPlaceholder } from "@/core/document-commenter/components/Comment/CommentAreaPlaceholder";
+import { useAreaSelect } from "@/core/document-commenter/hooks/useAreaSelect";
+import { PdfViewer } from "@/core/document-viewer/components/DocumentViewer";
+
+const PDF_MIN_SCALE = 0.4;
+const PDF_MAX_SCALE = 3.0;
+const PDF_SCALE_STEP = 0.2;
+
+export const PortfolioFeedbackWidget = () => {
+    const [scale, setScale] = useState<number>(1);
+    const [, toggleCommentMode] = useToggle(false);
+    // TODO: commentMode 활용하여 주석 기능 활성화/비활성화 구현
+
+    const {
+        rootElementRef,
+        areaSelectionBoxStyle,
+        handleMouseDown,
+        handleMouseMove,
+        handleMouseUp,
+    } = useAreaSelect();
+
+    return (
+        <Fragment>
+            <PortfolioFeedbackCommentToolbarWidget
+                onCommentModeToggle={() => toggleCommentMode()}
+                onZoomIn={() => setScale((prev) => Math.min(prev + PDF_SCALE_STEP, PDF_MAX_SCALE))}
+                onZoomOut={() => setScale((prev) => Math.max(prev - PDF_SCALE_STEP, PDF_MIN_SCALE))}
+            />
+            <PdfViewer
+                className="p-4"
+                viewerWidth="100%"
+                render={({ width, currentPage, initializePages }) => (
+                    <Document
+                        scale={scale}
+                        file="/mocks/v1-sample.pdf"
+                        onLoadSuccess={({ numPages }) => initializePages?.(numPages)}
+                    >
+                        <DisableSelection className="relative">
+                            <Page
+                                width={width}
+                                canvasRef={rootElementRef}
+                                pageNumber={currentPage}
+                                onMouseDown={handleMouseDown}
+                                onMouseMove={handleMouseMove}
+                                onMouseUp={handleMouseUp}
+                                renderAnnotationLayer={false}
+                                renderTextLayer={false}
+                            />
+
+                            {areaSelectionBoxStyle && (
+                                <CommentAreaPlaceholder
+                                    borderColor="#F6B13B"
+                                    backgroundColor="#F6B13B33"
+                                    style={areaSelectionBoxStyle}
+                                />
+                            )}
+                        </DisableSelection>
+                    </Document>
+                )}
+            />
+        </Fragment>
+    );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,6 +854,14 @@
     "@radix-ui/react-primitive" "2.1.3"
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
+"@radix-ui/react-presence@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.5.tgz#5d8f28ac316c32f078afce2996839250c10693db"
+  integrity sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
 "@radix-ui/react-primitive@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz#db9b8bcff49e01be510ad79893fb0e4cda50f1bc"
@@ -894,6 +902,33 @@
   integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
+
+"@radix-ui/react-toggle@^1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz#b04ba0f9609599df666fce5b2f38109a197f08cf"
+  integrity sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
+"@radix-ui/react-tooltip@^1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz#3f50267e25bccfc9e20bb3036bfd9ab4c2c30c2c"
+  integrity sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.11"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-popper" "1.2.8"
+    "@radix-ui/react-portal" "1.1.9"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-visually-hidden" "1.2.3"
 
 "@radix-ui/react-use-callback-ref@1.1.1":
   version "1.1.1"


### PR DESCRIPTION
## ✅ Linked Issue

- resolve #31

## 🔍 What I did

<!-- 이번 PR에서 무엇을 했나요? (변경 사항 요약) -->

- 사용자가 마우스 드래그를 통해 문서의 특정 영역을 선택할 수 있는 `CommentAreaPlaceholder` 를 구현 및 스토리북을 작성했습니다
- 영역 선택 완료 후 보이는 `CommentArea` 컴포넌트를 구현 및 스토리북을 작성했습니다
- `react-pdf` 의 `<Page/>` 컴포넌트에서 드래그 인터랙션 관련 상태를 `useAreaSelect` 훅의 `useState` 로 관리하고, 계산된 영역 정보를 props 로 `<CommentAreaPlaceholder/>` 에 전달하도록 구현하였습니다

## 💡 Why I did it

<!-- 이렇게 구현하거나 변경한 이유는? (의도/배경/기획) -->

<img width="600" height="551" alt="image" src="https://github.com/user-attachments/assets/94bd0e05-2057-4872-8d7d-7204ecab51b5" />

- `onMouseMove` 와 같이 매우 빈번하게 발생하는 이벤트 핸들러 내에서 `setState` 호출시, 마우스의 작은 움직임 하나하나에 전체 컴포넌트의 리렌더링이 트리거되어 심각한 성능 병목 현상이 발생
  - 이로 인해 과도한 리렌더링으로 드래그 인터랙션이 뚝뚝 끊기는 현상이 발생했습니다
  - throttle 이나 debounce 는 실시간 마우스 위치 좌표를 추적해야하는 기능에는 적합하지 않다고 판단하였습니다

## 🔧 Additional context

<!-- 관련된 이슈, 레퍼런스, 고민한 점 등 -->

- 선언적 방식 vs 명령적 방식에 대한 고민
  - React의 선언적인 상태 관리(useState)는 코드의 직관성을 높여주지만, 고빈도 이벤트 처리에는 적합하지 않다고 생각됩니다
  - 성능 최적화를 위해 useRef를 활용하여 DOM을 직접 제어하는 명령적 방식으로 변경할 예정입니다

## 🚧 TODO (if any)

<!-- 남은 작업이 있다면 적어주세요 -->

- [ ] useState로 관리되던 드래그 관련 상태를 useRef로 이전하여 불필요한 리렌더링을 방지하는 성능 개선 작업 진행
- [ ] 향후 확장성을 고려하여, 컴포넌트 간의 결합도를 낮출 수 있는 이벤트 버스(Event Bus) 아키텍처 도입


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 멘티 피드백 페이지 추가(이력서/포트폴리오/자기소개서 탭) 및 라우트 추가.
  - 포트폴리오 피드백 위젯: PDF 뷰어, 확대/축소, 영역 선택(주석 플레이스홀더)과 툴바(댓글 토글·버튼) 제공.
- 개선
  - PDF 뷰어 폭을 속성으로 제어해 화면 분할/레이아웃 유연성 향상.
  - 텍스트 선택/이미지 드래그 방지 유틸 추가로 상호작용 안정성 개선.
- 스타일
  - 사이드 내비게이션에 우측 보더 추가로 시각적 구분 강화.
- 기타
  - 토글·툴팁 관련 UI 및 라이브러리 의존성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->