### PR TITLE
Refactor#25 [김대건] 이벤트 버스 아키텍쳐 도입하여 UI 와 인터랙션 로직 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,52 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    test:
+        name: "Run Unit & Integration Tests"
+        needs: danger-js
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: "Checkout"
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node.js (with Yarn cache)
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+                  cache: "yarn"
+
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache Dependencies
+              uses: actions/cache@v4
+              id: yarn-cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
+
+            - name: Cache node_modules
+              uses: actions/cache@v4
+              id: node-modules-cache
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-modules-
+
+            - name: Install dependencies
+              if: steps.node-modules-cache.outputs.cache-hit != 'true'
+              run: yarn install --frozen-lockfile --prefer-offline
+
+            - name: Run tests
+              run: yarn test --coverage
+
     storybook:
         name: Build & Publish Storybook
         needs: danger-js

--- a/src/@types/utils.d.ts
+++ b/src/@types/utils.d.ts
@@ -1,0 +1,1 @@
+declare type Nullable<T> = T | null;

--- a/src/core/document-commenter/__tests__/EventBus.test.ts
+++ b/src/core/document-commenter/__tests__/EventBus.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect, vitest } from "vitest";
+
+import { EventBus } from "@/core/document-commenter/events/EventBus";
+
+describe("EventBus", () => {
+    const TEST_EVENT_KEY = "test:event";
+
+    test("subscribe() 가 호출되면 listeners 에 핸들러가 등록된다", () => {
+        const eventBus = new EventBus();
+
+        const eventHandler = vitest.fn();
+
+        expect(eventBus.listeners.get(TEST_EVENT_KEY)).toBeUndefined();
+        eventBus.subscribe(TEST_EVENT_KEY, eventHandler);
+
+        expect(eventBus.listeners.get(TEST_EVENT_KEY)).toContain(eventHandler);
+    });
+
+    test("unsubscribe() 가 호출되면 listeners 에서 핸들러가 제거된다", () => {
+        const eventBus = new EventBus();
+
+        const eventHandler = vitest.fn();
+        eventBus.subscribe(TEST_EVENT_KEY, eventHandler);
+        expect(eventBus.listeners.get(TEST_EVENT_KEY)).toContain(eventHandler);
+
+        eventBus.unsubscribe(TEST_EVENT_KEY, eventHandler);
+        expect(eventBus.listeners.get(TEST_EVENT_KEY)).not.toContain(eventHandler);
+    });
+
+    test("dispatch() 이 호출되면 listeners 에 등록된 핸들러가 호출된다", () => {
+        const eventBus = new EventBus();
+
+        const eventHandler = vitest.fn();
+        eventBus.subscribe(TEST_EVENT_KEY, eventHandler);
+
+        eventBus.dispatch({
+            type: TEST_EVENT_KEY,
+            payload: { message: "Test Message" },
+        });
+
+        expect(eventHandler).toHaveBeenCalledWith({
+            type: TEST_EVENT_KEY,
+            payload: { message: "Test Message" },
+        });
+    });
+
+    test("use() 가 호출되면 EventController 가 attach 된다", () => {
+        const eventBus = new EventBus();
+
+        const mockEventController = {
+            attach: vitest.fn(),
+        };
+
+        eventBus.use(mockEventController);
+
+        expect(mockEventController.attach).toHaveBeenCalledWith(eventBus);
+    });
+});

--- a/src/core/document-commenter/__tests__/SelectionEventController.test.ts
+++ b/src/core/document-commenter/__tests__/SelectionEventController.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, vitest } from "vitest";
+
+import { EventBus } from "@/core/document-commenter/events/EventBus";
+import { SelectionEventController } from "@/core/document-commenter/events/SelectionEventController";
+
+describe("SelectionEventController", () => {
+    test("마우스 이벤트에 따라 상태가 전이된다", () => {
+        const selectionEventController = new SelectionEventController();
+        const eventBus = new EventBus().use(selectionEventController);
+
+        expect(selectionEventController.state).toBe("idle");
+
+        eventBus.dispatch({
+            type: "document:mousedown",
+            payload: { x: 10, y: 10 },
+        });
+
+        expect(selectionEventController.state).toBe("dragging");
+
+        eventBus.dispatch({
+            type: "document:mousemove",
+            payload: { x: 20, y: 20 },
+        });
+
+        expect(selectionEventController.state).toBe("dragging");
+
+        eventBus.dispatch({
+            type: "document:mouseup",
+            payload: { x: 30, y: 30 },
+        });
+
+        expect(selectionEventController.state).toBe("idle");
+    });
+
+    test("선택 이벤트가 올바르게 디스패치된다", () => {
+        const selectionEventController = new SelectionEventController();
+        const eventBus = new EventBus().use(selectionEventController);
+
+        const selectionStartHandler = vitest.fn();
+        const selectionMoveHandler = vitest.fn();
+        const selectionEndHandler = vitest.fn();
+
+        eventBus.subscribe("selection:start", selectionStartHandler);
+        eventBus.subscribe("selection:move", selectionMoveHandler);
+        eventBus.subscribe("selection:end", selectionEndHandler);
+
+        eventBus.dispatch({
+            type: "document:mousedown",
+            payload: { x: 10, y: 10 },
+        });
+
+        expect(selectionStartHandler).toHaveBeenCalledWith({
+            type: "selection:start",
+            payload: { x: 10, y: 10 },
+        });
+
+        eventBus.dispatch({
+            type: "document:mousemove",
+            payload: { x: 20, y: 20 },
+        });
+
+        expect(selectionEndHandler).not.toHaveBeenCalled();
+        expect(selectionMoveHandler).toHaveBeenCalledWith({
+            type: "selection:move",
+            payload: { start: { x: 10, y: 10 }, current: { x: 20, y: 20 } },
+        });
+
+        eventBus.dispatch({
+            type: "document:mouseup",
+            payload: { x: 30, y: 30 },
+        });
+
+        expect(selectionEndHandler).toHaveBeenCalledWith({
+            type: "selection:end",
+            payload: { start: { x: 10, y: 10 }, end: { x: 30, y: 30 } },
+        });
+    });
+});

--- a/src/core/document-commenter/__tests__/SelectionEventController.test.ts
+++ b/src/core/document-commenter/__tests__/SelectionEventController.test.ts
@@ -75,4 +75,38 @@ describe("SelectionEventController", () => {
             payload: { start: { x: 10, y: 10 }, end: { x: 30, y: 30 } },
         });
     });
+
+    test("idle 상태에서는 mousemove와 mouseup 이벤트를 무시한다", () => {
+        const selectionEventController = new SelectionEventController();
+        const eventBus = new EventBus().use(selectionEventController);
+        const moveHandler = vitest.fn();
+        const endHandler = vitest.fn();
+
+        eventBus.subscribe("selection:move", moveHandler);
+        eventBus.subscribe("selection:end", endHandler);
+
+        eventBus.dispatch({ type: "document:mousemove", payload: { x: 20, y: 20 } });
+        eventBus.dispatch({ type: "document:mouseup", payload: { x: 30, y: 30 } });
+
+        expect(selectionEventController.state).toBe("idle");
+
+        expect(moveHandler).not.toHaveBeenCalled();
+        expect(endHandler).not.toHaveBeenCalled();
+    });
+
+    test("dragging 상태에서는 mousedown 이벤트를 무시한다", () => {
+        const selectionEventController = new SelectionEventController();
+        const eventBus = new EventBus().use(selectionEventController);
+        const startHandler = vitest.fn();
+
+        eventBus.subscribe("selection:start", startHandler);
+
+        eventBus.dispatch({ type: "document:mousedown", payload: { x: 10, y: 10 } });
+
+        eventBus.dispatch({ type: "document:mousedown", payload: { x: 50, y: 50 } });
+
+        expect(selectionEventController.state).toBe("dragging");
+        expect(selectionEventController.startPosition).toEqual({ x: 10, y: 10 });
+        expect(startHandler).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/core/document-commenter/components/Comment/CommentAreaPlaceholder.tsx
+++ b/src/core/document-commenter/components/Comment/CommentAreaPlaceholder.tsx
@@ -1,23 +1,67 @@
-import { type CSSProperties } from "react";
+import { useEffect, useRef, type CSSProperties } from "react";
+
+import { useEventBus } from "@/core/document-commenter/contexts/EventBusContext";
+import type { EventHandlerOf } from "@/core/document-commenter/events/EventTypes";
 
 export interface CommentAreaPlaceholderProps {
     borderColor: CSSProperties["borderColor"];
     backgroundColor: CSSProperties["backgroundColor"];
-    style: CSSProperties;
 }
 
 export const CommentAreaPlaceholder = ({
-    style,
     borderColor,
     backgroundColor,
 }: CommentAreaPlaceholderProps) => {
+    const areaPlaceholderRef = useRef<HTMLElement>(null);
+    const eventBus = useEventBus();
+    const startPosition = useRef<Vector2d>({ x: 0, y: 0 });
+    const currentPosition = useRef<Vector2d>({ x: 0, y: 0 });
+
+    useEffect(() => {
+        const handleSelectionStart: EventHandlerOf<"selection:start"> = (event) => {
+            startPosition.current = event.payload;
+            if (!areaPlaceholderRef.current) return;
+
+            Object.assign(areaPlaceholderRef.current.style, {
+                top: `${event.payload.y}px`,
+                left: `${event.payload.x}px`,
+                width: "0px",
+                height: "0px",
+            });
+        };
+
+        const handleSelectionMove: EventHandlerOf<"selection:move"> = (event) => {
+            currentPosition.current = event.payload.current;
+            if (!areaPlaceholderRef.current) return;
+
+            const width = event.payload.current.x - startPosition.current.x;
+            const height = event.payload.current.y - startPosition.current.y;
+
+            Object.assign(areaPlaceholderRef.current.style, {
+                width: `${Math.abs(width)}px`,
+                height: `${Math.abs(height)}px`,
+                left: width < 0 ? `${event.payload.current.x}px` : undefined,
+                top: height < 0 ? `${event.payload.current.y}px` : undefined,
+            });
+        };
+
+        eventBus.subscribe("selection:start", handleSelectionStart);
+        eventBus.subscribe("selection:move", handleSelectionMove);
+
+        return () => {
+            eventBus.unsubscribe("selection:start", handleSelectionStart);
+            eventBus.unsubscribe("selection:move", handleSelectionMove);
+        };
+    }, [eventBus]);
+
     return (
         <mark
+            ref={areaPlaceholderRef}
             style={{
                 position: "absolute",
                 border: `1px dashed ${borderColor}`,
                 backgroundColor,
-                ...style,
+                pointerEvents: "none",
             }}
         />
     );

--- a/src/core/document-commenter/contexts/EventBusContext.tsx
+++ b/src/core/document-commenter/contexts/EventBusContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useRef, type PropsWithChildren } from "react";
+
+import { EventBus } from "@/core/document-commenter/events/EventBus";
+import type { EventController } from "@/core/document-commenter/events/EventController";
+
+export const EventBusContext = createContext<EventBus | null>(null);
+
+export interface EventBusProviderProps extends PropsWithChildren {
+    eventControllers?: Array<EventController>;
+}
+
+export const EventBusProvider = ({
+    children,
+    eventControllers,
+}: EventBusProviderProps) => {
+    const eventBus = useRef<Nullable<EventBus>>(null);
+
+    if (!eventBus.current) {
+        eventBus.current = new EventBus();
+
+        eventControllers?.forEach((controller) => {
+            eventBus.current?.use(controller);
+        });
+    }
+
+    return <EventBusContext.Provider value={eventBus.current}>{children}</EventBusContext.Provider>;
+};
+
+export const useEventBus = () => {
+    const eventBus = useContext(EventBusContext);
+    if (!eventBus) {
+        throw new Error("useEventBus must be used within an EventBusProvider");
+    }
+    return eventBus;
+};

--- a/src/core/document-commenter/events/EventBus.ts
+++ b/src/core/document-commenter/events/EventBus.ts
@@ -1,0 +1,39 @@
+import type { EventController } from "@/core/document-commenter/events/EventController";
+import type {
+    EventHandlerOf,
+    EventTypeOf,
+    EventTypes,
+} from "@/core/document-commenter/events/EventTypes";
+
+export class EventBus {
+    public listeners = new Map<keyof EventTypes, Array<EventHandlerOf<keyof EventTypes>>>();
+
+    public subscribe<K extends keyof EventTypes>(eventType: K, handler: EventHandlerOf<K>) {
+        if (!this.listeners.has(eventType)) {
+            this.listeners.set(eventType, []);
+        }
+        this.listeners.get(eventType)?.push(handler as EventHandlerOf<keyof EventTypes>);
+    }
+
+    public unsubscribe<K extends keyof EventTypes>(eventType: K, handler: EventHandlerOf<K>) {
+        const handlers = this.listeners.get(eventType);
+        if (handlers) {
+            this.listeners.set(
+                eventType,
+                handlers.filter((h) => h !== handler),
+            );
+        }
+    }
+
+    public dispatch(event: EventTypeOf<keyof EventTypes>) {
+        const handlers = this.listeners.get(event.type);
+        if (handlers) {
+            handlers.forEach((handler) => handler(event));
+        }
+    }
+
+    public use(eventController: EventController) {
+        eventController.attach(this);
+        return this;
+    }
+}

--- a/src/core/document-commenter/events/EventController.ts
+++ b/src/core/document-commenter/events/EventController.ts
@@ -1,0 +1,5 @@
+import type { EventBus } from "@/core/document-commenter/events/EventBus";
+
+export abstract class EventController {
+    public abstract attach(eventBus: EventBus): void;
+}

--- a/src/core/document-commenter/events/EventTypes.ts
+++ b/src/core/document-commenter/events/EventTypes.ts
@@ -1,0 +1,18 @@
+export type EventTypes = {
+    [key: string]: unknown;
+
+    "document:mousedown": Vector2d;
+    "document:mousemove": Vector2d;
+    "document:mouseup": Vector2d;
+
+    "selection:start": Vector2d;
+    "selection:move": { start: Vector2d; current: Vector2d };
+    "selection:end": { start: Vector2d; end: Vector2d };
+};
+
+export type EventTypeOf<T extends keyof EventTypes> = {
+    type: T;
+    payload: EventTypes[T];
+};
+
+export type EventHandlerOf<T extends keyof EventTypes> = (event: EventTypeOf<T>) => void;

--- a/src/core/document-commenter/events/SelectionEventController.ts
+++ b/src/core/document-commenter/events/SelectionEventController.ts
@@ -1,0 +1,52 @@
+import { EventBus } from "@/core/document-commenter/events/EventBus";
+import { EventController } from "@/core/document-commenter/events/EventController";
+import type { EventHandlerOf } from "@/core/document-commenter/events/EventTypes";
+
+export type SelectionState = "idle" | "dragging";
+
+export class SelectionEventController extends EventController {
+    private eventBus: Nullable<EventBus> = null;
+
+    public state: SelectionState = "idle";
+    public startPosition: Vector2d = { x: 0, y: 0 };
+
+    public override attach(eventBus: EventBus): void {
+        this.eventBus = eventBus;
+
+        this.eventBus.subscribe("document:mousedown", this.handleMouseDown);
+        this.eventBus.subscribe("document:mousemove", this.handleMouseMove);
+        this.eventBus.subscribe("document:mouseup", this.handleMouseUp);
+    }
+
+    private handleMouseDown: EventHandlerOf<"document:mousedown"> = (event) => {
+        if (this.state !== "idle") return;
+
+        this.state = "dragging";
+        this.startPosition = event.payload;
+
+        this.eventBus?.dispatch({
+            type: "selection:start",
+            payload: this.startPosition,
+        });
+    };
+
+    private handleMouseMove: EventHandlerOf<"document:mousemove"> = (event) => {
+        if (this.state !== "dragging") return;
+
+        this.eventBus?.dispatch({
+            type: "selection:move",
+            payload: { start: this.startPosition, current: event.payload },
+        });
+    };
+
+    private handleMouseUp: EventHandlerOf<"document:mouseup"> = (event) => {
+        if (this.state !== "dragging") return;
+
+        this.state = "idle";
+
+        this.eventBus?.dispatch({
+            type: "selection:end",
+            payload: { start: this.startPosition, end: event.payload },
+        });
+    };
+}

--- a/src/core/document-commenter/hooks/useLocalCoordinates.ts
+++ b/src/core/document-commenter/hooks/useLocalCoordinates.ts
@@ -1,0 +1,15 @@
+import { useRef, useCallback } from "react";
+
+export const useLocalCoordinates = <T extends HTMLElement>() => {
+    const elementRef = useRef<T>(null);
+
+    const getCoords = useCallback((coords: Vector2d) => {
+        if (!elementRef.current) return null;
+
+        const rect = elementRef.current.getBoundingClientRect();
+
+        return { x: coords.x - rect.left, y: coords.y - rect.top };
+    }, []);
+
+    return { ref: elementRef, getCoords };
+};

--- a/src/pages/mentee/MenteeFeedbackPage.tsx
+++ b/src/pages/mentee/MenteeFeedbackPage.tsx
@@ -9,6 +9,9 @@ import { TabNavBar } from "@/shared/components/Tab/TabNavBar";
 
 import { PortfolioFeedbackWidget } from "@/widgets/document-feedback/PortfolioFeedbackWidget";
 
+import { EventBusProvider } from "@/core/document-commenter/contexts/EventBusContext";
+import { SelectionEventController } from "@/core/document-commenter/events/SelectionEventController";
+
 export default function MenteeFeedbackPage() {
     return (
         <Fragment>
@@ -35,7 +38,9 @@ export default function MenteeFeedbackPage() {
                     <div>이력서 피드백 위젯</div>
                 </TabItem>
                 <TabItem menu="포트폴리오">
-                    <PortfolioFeedbackWidget />
+                    <EventBusProvider eventControllers={[new SelectionEventController()]}>
+                        <PortfolioFeedbackWidget />
+                    </EventBusProvider>
                 </TabItem>
                 <TabItem menu="자기소개서">
                     <div>자기소개서 피드백 위젯</div>

--- a/src/widgets/document-feedback/PortfolioFeedbackCommentToolbar.tsx
+++ b/src/widgets/document-feedback/PortfolioFeedbackCommentToolbar.tsx
@@ -1,5 +1,3 @@
-import { Fragment } from "react/jsx-runtime";
-
 import { MessageSquarePlus, ZoomIn, ZoomOut } from "lucide-react";
 
 import {
@@ -23,26 +21,27 @@ export const PortfolioFeedbackCommentToolbarWidget = ({
         <CommentToolbar
             leftItems={[
                 <CommentToolbarToggleItem
+                    key="comment-mode"
                     tooltip="댓글 추가"
                     icon={<MessageSquarePlus />}
                     onToggle={onCommentModeToggle}
                 />,
             ]}
             rightItems={[
-                <Fragment>
-                    <CommentToolbarButtonItem
-                        tooltip="확대"
-                        className="h-full w-5"
-                        icon={<ZoomIn size={16} />}
-                        onClick={onZoomIn}
-                    />
-                    <CommentToolbarButtonItem
-                        tooltip="축소"
-                        className="h-full w-5"
-                        icon={<ZoomOut size={16} />}
-                        onClick={onZoomOut}
-                    />
-                </Fragment>,
+                <CommentToolbarButtonItem
+                    key="zoom-in"
+                    tooltip="확대"
+                    className="h-full w-5"
+                    icon={<ZoomIn size={16} />}
+                    onClick={onZoomIn}
+                />,
+                <CommentToolbarButtonItem
+                    key="zoom-out"
+                    tooltip="축소"
+                    className="h-full w-5"
+                    icon={<ZoomOut size={16} />}
+                    onClick={onZoomOut}
+                />,
             ]}
         />
     );

--- a/src/widgets/document-feedback/PortfolioFeedbackWidget.tsx
+++ b/src/widgets/document-feedback/PortfolioFeedbackWidget.tsx
@@ -41,12 +41,10 @@ export const PortfolioFeedbackWidget = () => {
 
     const onMouseUp = useCallback(
         (event: React.MouseEvent) => {
-            eventBus.dispatch({
-                type: "document:mouseup",
-                payload: { x: event.clientX, y: event.clientY },
-            });
+            const localCoords = getCoords({ x: event.clientX, y: event.clientY });
+            eventBus.dispatch({ type: "document:mouseup", payload: localCoords });
         },
-        [eventBus],
+        [eventBus, getCoords],
     );
 
     return (

--- a/src/widgets/document-feedback/PortfolioFeedbackWidget.tsx
+++ b/src/widgets/document-feedback/PortfolioFeedbackWidget.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from "react";
+import { Fragment, useCallback, useState } from "react";
 import { Document, Page } from "react-pdf";
 
 import { DisableSelection } from "@/shared/components/Helper/DisableSelection";
@@ -7,7 +7,8 @@ import { useToggle } from "@/shared/hooks/useToggle";
 import { PortfolioFeedbackCommentToolbarWidget } from "@/widgets/document-feedback/PortfolioFeedbackCommentToolbar";
 
 import { CommentAreaPlaceholder } from "@/core/document-commenter/components/Comment/CommentAreaPlaceholder";
-import { useAreaSelect } from "@/core/document-commenter/hooks/useAreaSelect";
+import { useEventBus } from "@/core/document-commenter/contexts/EventBusContext";
+import { useLocalCoordinates } from "@/core/document-commenter/hooks/useLocalCoordinates";
 import { PdfViewer } from "@/core/document-viewer/components/DocumentViewer";
 
 const PDF_MIN_SCALE = 0.4;
@@ -19,13 +20,34 @@ export const PortfolioFeedbackWidget = () => {
     const [, toggleCommentMode] = useToggle(false);
     // TODO: commentMode 활용하여 주석 기능 활성화/비활성화 구현
 
-    const {
-        rootElementRef,
-        areaSelectionBoxStyle,
-        handleMouseDown,
-        handleMouseMove,
-        handleMouseUp,
-    } = useAreaSelect();
+    const eventBus = useEventBus();
+    const { ref: pageRef, getCoords } = useLocalCoordinates<HTMLCanvasElement>();
+
+    const onMouseDown = useCallback(
+        (event: React.MouseEvent) => {
+            const localCoords = getCoords({ x: event.clientX, y: event.clientY });
+            eventBus.dispatch({ type: "document:mousedown", payload: localCoords });
+        },
+        [eventBus, getCoords],
+    );
+
+    const onMouseMove = useCallback(
+        (event: React.MouseEvent) => {
+            const localCoords = getCoords({ x: event.clientX, y: event.clientY });
+            eventBus.dispatch({ type: "document:mousemove", payload: localCoords });
+        },
+        [eventBus, getCoords],
+    );
+
+    const onMouseUp = useCallback(
+        (event: React.MouseEvent) => {
+            eventBus.dispatch({
+                type: "document:mouseup",
+                payload: { x: event.clientX, y: event.clientY },
+            });
+        },
+        [eventBus],
+    );
 
     return (
         <Fragment>
@@ -46,22 +68,19 @@ export const PortfolioFeedbackWidget = () => {
                         <DisableSelection className="relative">
                             <Page
                                 width={width}
-                                canvasRef={rootElementRef}
+                                canvasRef={pageRef}
                                 pageNumber={currentPage}
-                                onMouseDown={handleMouseDown}
-                                onMouseMove={handleMouseMove}
-                                onMouseUp={handleMouseUp}
+                                onMouseDown={onMouseDown}
+                                onMouseMove={onMouseMove}
+                                onMouseUp={onMouseUp}
                                 renderAnnotationLayer={false}
                                 renderTextLayer={false}
                             />
 
-                            {areaSelectionBoxStyle && (
-                                <CommentAreaPlaceholder
-                                    borderColor="#F6B13B"
-                                    backgroundColor="#F6B13B33"
-                                    style={areaSelectionBoxStyle}
-                                />
-                            )}
+                            <CommentAreaPlaceholder
+                                borderColor="#F6B13B"
+                                backgroundColor="#F6B13B33"
+                            />
                         </DisableSelection>
                     </Document>
                 )}


### PR DESCRIPTION
## ✅ Linked Issue

- #25

## 🔍 What I did

<!-- 이번 PR에서 무엇을 했나요? (변경 사항 요약) -->

- 컴포넌트 간의 의존성을 낮추고 로직을 분리하기 위해 `Event Bus` 아키텍처를 도입했습니다.
- `EventController` 추상 클래스를 구현하여, `SelectionEventController` 등 다양한 사용자 인터랙션을 처리하는 '플러그인' 형태의 컨트롤러를 확장 가능하도록 설계했습니다
- 저수준 DOM 이벤트(`document:mousedown` 등)를 `EventController`가 구독하여, 고수준 의미론적 이벤트(`selection:end` 등)로 변환하여 발행하는 로직을 구현했습니다.
- 반복되는 좌표 변환 로직을 `useLocalCoordinates` 커스텀 훅으로 분리하여 재사용성을 높였습니다.

## 💡 Why I did it

<!-- 이렇게 구현하거나 변경한 이유는? (의도/배경/기획) -->

- 기존에는 useRef를 사용하여 성능을 최적화했지만, 모든 로직이 View 컴포넌트(`PortfolioFeedbackWidget`)에 집중되어 컴포넌트가 비대해지고 유지보수가 어려워지는 문제가 있었습니다
- 향후 추가될 줌(Zoom), 패닝(Panning) 등의 복잡한 인터랙션을 고려했을 때, 각 기능이 독립적으로 개발 및 테스트될 수 있는 확장 가능한 구조가 필요했습니다
- 관심사 분리를 통해 View 컴포넌트는 오직 화면을 그리고 원시 이벤트를 전달하는 역할만, EventController는 비즈니스 로직을 처리하는 역할만 담당하도록 하여 코드의 명확성과 안정성을 높이고자 했습니다

## 🧠 What I learned

<!-- 작업하면서 배운 점, 알게 된 개념이 있다면 정리 -->

- [미디에이터 패턴(Mediator Pattern)](https://refactoring.guru/ko/design-patterns/mediator): EventController가 여러 컴포넌트 간의 복잡한 상호작용을 중재하는 역할을 하는 미디에이터 패턴을 적용하며, 객체 간의 결합도를 낮추는 방법을 학습했습니다.
- 아키텍처의 트레이드오프: 이벤트 버스 아키텍처는 느슨한 결합으로 인해 각 로직을 독립적으로 테스트하기 용이하지만, 데이터 흐름이 암시적이어서 런타임 디버깅이 더 어려워질 수 있다는 장단점을 알게되었습니다

## 🧪 How to test

<!-- 테스트 방법 또는 테스트 결과 캡쳐 (선택사항) -->

- EventBus의 모든 public 메서드(subscribe, unsubscribe, dispatch, use)가 의도대로 동작하는지 검증하는 단위 테스트를 작성했습니다
- SelectionEventController에 대한 단위 테스트를 실행하여, 저수준 이벤트에 따라 상태 머신이 올바르게 동작하고 고수준 이벤트를 정확히 발행하는지 확인했습니다

## 🔧 Additional context

<img src="https://github.com/user-attachments/assets/5bdd805d-1f85-4efe-afe7-412000a494bb" alt="클래스다이어그램" width="600px"/>

<img src="https://github.com/user-attachments/assets/fd534f7c-f129-4329-b3a0-061d0ef9fb2b" alt="SelectionEventController 상태머신" width="600px"/>


## 🚧 TODO (if any)

<!-- 남은 작업이 있다면 적어주세요 -->

- [ ] ZoomEventController 구현
- [ ] PanEventController 구현
- [ ] 이벤트 흐름 디버깅을 위한 로깅 시스템 도입 고려 (redux devtools 비슷한거??)